### PR TITLE
Replace global whitespace removal regex with more specific regex for CSS properties

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,9 @@ jobs:
 
       - name: install packages
         run: pnpm install
+
+      - name: Build packages
+        run: pnpm turbo run build
+
+      - name: Run test
+        run: pnpm test

--- a/packages/babel-plugin/CHANGELOG.md
+++ b/packages/babel-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @kuma-ui/babel-plugin
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @kuma-ui/sheet@0.0.3
+  - @kuma-ui/system@0.1.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/babel-plugin",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @kuma-ui/core
 
+## 0.0.3
+
+### Patch Changes
+
+- Replace global whitespace removal regex with more specific regex for CSS properties #23
+  Refactor HTML Tags. #24
+  Fix incorrect setup example for Next.js #25
+  fix position 'bottom, inset' css prop values #26
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/next-plugin/CHANGELOG.md
+++ b/packages/next-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kuma-ui/next-plugin
 
+## 0.1.1
+
+### Patch Changes
+
+- @kuma-ui/webpack-plugin@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/next-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/sheet/CHANGELOG.md
+++ b/packages/sheet/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @kuma-ui/sheet
 
+## 0.0.3
+
+### Patch Changes
+
+- Replace global whitespace removal regex with more specific regex for CSS properties #23
+  Refactor HTML Tags. #24
+  Fix incorrect setup example for Next.js #25
+  fix position 'bottom, inset' css prop values #26
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -30,8 +30,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "@kuma-ui/system": "workspace:^"
   }
 }

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/sheet",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -30,5 +30,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@kuma-ui/system": "workspace:^"
   }
 }

--- a/packages/sheet/src/index.ts
+++ b/packages/sheet/src/index.ts
@@ -1,2 +1,3 @@
 export { sheet } from "./sheet";
 export { theme } from "./theme";
+export * from "./regex";

--- a/packages/sheet/src/regex.test.ts
+++ b/packages/sheet/src/regex.test.ts
@@ -1,0 +1,83 @@
+import { cssPropertyRegex, removeSpacesExceptInPropertiesRegex } from "./regex";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+describe("regex", () => {
+  describe("cssPropertyRegex", () => {
+    // Arrange
+    const testCases = [
+      { input: "color: red;", expected: "color:red;" },
+      { input: "padding: 10px 20px;", expected: "padding:10px 20px;" },
+      {
+        input: "margin: 5px 10px 5px 10px;",
+        expected: "margin:5px 10px 5px 10px;",
+      },
+      {
+        input: "background-color: rgba(0, 0, 0, 0.5);",
+        expected: "background-color:rgba(0, 0, 0, 0.5);",
+      },
+      {
+        input: "font: 14px Arial, sans-serif;",
+        expected: "font:14px Arial, sans-serif;",
+      },
+      {
+        input: "border: 1px solid black;",
+        expected: "border:1px solid black;",
+      },
+      {
+        input: "transform: rotate(90deg);",
+        expected: "transform:rotate(90deg);",
+      },
+      {
+        input:
+          "box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);",
+        expected:
+          "box-shadow:0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);",
+      },
+      {
+        input: "grid-template-columns: repeat(3, 1fr);",
+        expected: "grid-template-columns:repeat(3, 1fr);",
+      },
+      { input: "border-radius: 50%;", expected: "border-radius:50%;" },
+    ];
+
+    test.each(testCases)(
+      "should removes whitespace around CSS property values correctly",
+      ({ input, expected }) => {
+        // Act
+        const result = input.replace(cssPropertyRegex, "");
+        // Assert
+        expect(result).toStrictEqual(expected);
+      }
+    );
+  });
+
+  describe("removeSpacesExceptInPropertiesRegex", () => {
+    // Arrange
+    const testCases = [
+      { input: "padding: 10px 20px;", expected: "padding:10px 20px;" },
+      {
+        input: ".kuma-xxx&:hover { padding: 10px 20px; }",
+        expected: ".kuma-xxx&:hover{padding:10px 20px;}",
+      },
+      {
+        input: "@media(min-width: 768px) { .kuma-xxx { padding: 10px 20px; } }",
+        expected: "@media(min-width:768px){.kuma-xxx{padding:10px 20px;}}",
+      },
+      {
+        input:
+          "@media(min-width: 768px) { .kuma-xxx { padding: 10px 20px; border: 1px solid black; } }",
+        expected:
+          "@media(min-width:768px){.kuma-xxx{padding:10px 20px; border:1px solid black;}}",
+      },
+    ];
+    test.each(testCases)(
+      "should removes whitespace except around CSS property values and after commas",
+      ({ input, expected }) => {
+        // Act
+        const result = input.replace(removeSpacesExceptInPropertiesRegex, "");
+        // Assert
+        expect(result).toStrictEqual(expected);
+      }
+    );
+  });
+});

--- a/packages/sheet/src/regex.ts
+++ b/packages/sheet/src/regex.ts
@@ -1,0 +1,6 @@
+// removes white space around property values
+export const cssPropertyRegex = /(?<=:)\s+|\s+(?=;)/g;
+
+// removes whitespace except around CSS property values and after commas.
+export const removeSpacesExceptInPropertiesRegex =
+  /(?<=:)\s+|\s+(?=;)|(?<=\{)\s+|\s+(?=\})|(?<=,)\s+|\s+(?=,)|\s+(?={)/g;

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -1,6 +1,6 @@
 import { Sheet, sheet } from "./sheet";
 import { describe, expect, test, beforeEach } from "@jest/globals";
-import { removeSpacesExceptInPropertiesRegex } from "./regex";
+import { removeSpacesExceptInPropertiesRegex, cssPropertyRegex } from "./regex";
 
 describe("Sheet class", () => {
   beforeEach(() => {
@@ -62,7 +62,9 @@ describe("Sheet class", () => {
     // Act
     const cssString = sheet.getCSS();
     // Assert
-    expect(cssString).toContain(`.${id} {${css}}`.replace(/\s/g, ""));
+    expect(cssString).toContain(
+      `.${id} {${css}}`.replace(cssPropertyRegex, "")
+    );
   });
 
   test("getFromCache() should return undefined if no value is cached for the given key", () => {

--- a/packages/sheet/src/sheet.test.ts
+++ b/packages/sheet/src/sheet.test.ts
@@ -1,5 +1,6 @@
 import { Sheet, sheet } from "./sheet";
 import { describe, expect, test, beforeEach } from "@jest/globals";
+import { removeSpacesExceptInPropertiesRegex } from "./regex";
 
 describe("Sheet class", () => {
   beforeEach(() => {
@@ -34,7 +35,9 @@ describe("Sheet class", () => {
     // Act
     sheet.addMediaRule(className, css, breakpoint);
     // Assert
-    expect(sheet.getCSS()).toContain(mediaCss.replace(/\s/g, ""));
+    expect(sheet.getCSS()).toContain(
+      mediaCss.replace(removeSpacesExceptInPropertiesRegex, "")
+    );
   });
 
   test("addPseudoRule() should add a new pseudo rule with a generated ID", () => {
@@ -42,7 +45,10 @@ describe("Sheet class", () => {
     const className = "kuma-12345";
     const css = "padding: 8px;";
     const pseudo = ":hover";
-    const pseudoCss = `.${className}${pseudo} { ${css} }`.replace(/\s/g, "");
+    const pseudoCss = `.${className}${pseudo} { ${css} }`.replace(
+      removeSpacesExceptInPropertiesRegex,
+      ""
+    );
     // Act
     sheet.addPseudoRule(className, css, pseudo);
     // Assert

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -1,10 +1,6 @@
 import { generateHash } from "./hash";
-// import { ResponsiveStyle } from "../system"; //　モノレポ化により後ほど対応
-
-type ResponsiveStyle = {
-  base: string;
-  media: { [breakpoint: string]: string };
-};
+import type { ResponsiveStyle } from "@kuma-ui/system";
+import { cssPropertyRegex, removeSpacesExceptInPropertiesRegex } from "./regex";
 
 export interface Rule {
   id: string;
@@ -33,7 +29,7 @@ export class Sheet {
   }
 
   addRule(css: string): string {
-    css = css.replace(/\s/g, "");
+    css = css.replace(cssPropertyRegex, "");
     const id = "kuma-" + generateHash(css);
     const existingRule = this.rules.find((rule) => rule.id === id);
     if (!existingRule) this.rules.push({ id, css });
@@ -41,16 +37,21 @@ export class Sheet {
   }
 
   addMediaRule(className: string, css: string, breakpoint: string): void {
+    css = css.replace(cssPropertyRegex, "");
     const mediaCss =
       `@media (min-width: ${breakpoint}) { .${className} { ${css} } }`.replace(
-        /\s/g,
+        removeSpacesExceptInPropertiesRegex,
         ""
       );
     this.responsive.push(mediaCss);
   }
 
   addPseudoRule(className: string, css: string, pseudo: string): void {
-    const pseudoCss = `.${className}${pseudo} { ${css} }`.replace(/\s/g, "");
+    css = css.replace(cssPropertyRegex, "");
+    const pseudoCss = `.${className}${pseudo} { ${css} }`.replace(
+      removeSpacesExceptInPropertiesRegex,
+      ""
+    );
     this.pseudo.push(pseudoCss);
   }
 

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -1,6 +1,13 @@
 import { generateHash } from "./hash";
-import type { ResponsiveStyle } from "@kuma-ui/system";
 import { cssPropertyRegex, removeSpacesExceptInPropertiesRegex } from "./regex";
+
+// to avoid cyclic dependency, we declare an exact same type declared in @kuma-ui/system
+type ResponsiveStyle = {
+  base: string;
+  media: {
+    [breakpoint: string]: string;
+  };
+};
 
 export interface Rule {
   id: string;

--- a/packages/sheet/src/sheet.ts
+++ b/packages/sheet/src/sheet.ts
@@ -82,7 +82,7 @@ export class Sheet {
       this.rules
         .map((rule) => `.${rule.id} {${rule.css}}`)
         .join("\n")
-        .replace(/\s/g, "") +
+        .replace(cssPropertyRegex, "") +
       this.responsive.join("") +
       this.pseudo.join("")
     );

--- a/packages/system/CHANGELOG.md
+++ b/packages/system/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @kuma-ui/system
 
+## 0.1.1
+
+### Patch Changes
+
+- Replace global whitespace removal regex with more specific regex for CSS properties #23
+  Refactor HTML Tags. #24
+  Fix incorrect setup example for Next.js #25
+  fix position 'bottom, inset' css prop values #26
+- Updated dependencies
+  - @kuma-ui/sheet@0.0.3
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/system",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @kuma-ui/vite
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @kuma-ui/sheet@0.0.3
+  - @kuma-ui/babel-plugin@0.0.4
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/vite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/webpack-plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @kuma-ui/webpack-plugin
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @kuma-ui/sheet@0.0.3
+  - @kuma-ui/babel-plugin@0.0.4
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/webpack-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,7 +164,11 @@ importers:
         specifier: ^5.78.0
         version: 5.78.0(esbuild@0.17.18)
 
-  packages/sheet: {}
+  packages/sheet:
+    devDependencies:
+      '@kuma-ui/system':
+        specifier: workspace:^
+        version: link:../system
 
   packages/system:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,11 +164,7 @@ importers:
         specifier: ^5.78.0
         version: 5.78.0(esbuild@0.17.18)
 
-  packages/sheet:
-    devDependencies:
-      '@kuma-ui/system':
-        specifier: workspace:^
-        version: link:../system
+  packages/sheet: {}
 
   packages/system:
     dependencies:


### PR DESCRIPTION
Currently, the implementation uses a regex /\s/g to remove all whitespace characters in the CSS. This causes issues with some CSS properties that require whitespace to separate values, such as `padding: 10px 10px`.

To fix this, we should replace the global whitespace removal regex with a more specific regex that only removes whitespace around CSS property values. The new regex, `/((?<=:)\s+)|(\s+(?=;))/g`, should be used in place of the existing one.

This change will ensure that necessary whitespace is preserved within property values while still minimizing the CSS output.

Tasks:

1. Identify all instances where the /\s/g regex is used for CSS processing.
2. Replace the global whitespace removal regex with the new, more specific regex: `/((?<=:)\s+)|(\s+(?=;))/g`.
3. Implement the removeSpacesExceptInPropertiesRegex and use it in the addPseudoRule and addMediaRule functions.
4. Update tests to include cases with CSS properties that require whitespace-separated values and cases related to addPseudoRule and addMediaRule functions.
5. Verify that the updated implementation produces valid CSS output.

This PR also fixes #19