### PR TITLE
Remove TypeScript version setting from workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}


### PR DESCRIPTION
The reason for this change is that the TypeScript version used by VS Code should be left to each developer's individual environment.