### PR TITLE
Fix fontWeight property and add textDecoration

### DIFF
--- a/packages/babel-plugin/CHANGELOG.md
+++ b/packages/babel-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @kuma-ui/babel-plugin
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @kuma-ui/system@0.2.1
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/babel-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/next-plugin/CHANGELOG.md
+++ b/packages/next-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kuma-ui/next-plugin
 
+## 0.2.1
+
+### Patch Changes
+
+- @kuma-ui/webpack-plugin@0.3.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/next-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/system/CHANGELOG.md
+++ b/packages/system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kuma-ui/system
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix fontWeight property and add textDecoration
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/system",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/system/src/keys.ts
+++ b/packages/system/src/keys.ts
@@ -22,6 +22,7 @@ export const styleKeys = {
     "letterSpacing",
     "textAlign",
     "fontFamily",
+    "textDecoration",
   ] as const,
   layout: [
     "width",

--- a/packages/system/src/typography.ts
+++ b/packages/system/src/typography.ts
@@ -10,6 +10,7 @@ export type TypographyProps = Partial<{
   letterSpacing?: CSSValue<"letterSpacing", true>;
   textAlign?: CSSValue<"textAlign">;
   fontFamily?: CSSValue<"fontFamily">;
+  textDecoration?: CSSValue<"textDecoration">;
 }>;
 
 const typographyMappings: Record<TypographyKeys, string> = {
@@ -19,6 +20,7 @@ const typographyMappings: Record<TypographyKeys, string> = {
   letterSpacing: "letter-spacing",
   textAlign: "text-align",
   fontFamily: "font-family",
+  textDecoration: "text-decoration",
 };
 
 export const typography = (props: TypographyProps): ResponsiveStyle => {
@@ -31,7 +33,6 @@ export const typography = (props: TypographyProps): ResponsiveStyle => {
       const property = typographyMappings[key as TypographyKeys];
       const converter = [
         typographyMappings.fontSize,
-        typographyMappings.fontWeight,
         typographyMappings.lineHeight,
         typographyMappings.letterSpacing,
       ].includes(property)

--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kuma-ui/vite
 
+## 0.2.1
+
+### Patch Changes
+
+- @kuma-ui/babel-plugin@0.1.2
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/vite",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",

--- a/packages/webpack-plugin/CHANGELOG.md
+++ b/packages/webpack-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @kuma-ui/webpack-plugin
 
+## 0.3.1
+
+### Patch Changes
+
+- @kuma-ui/babel-plugin@0.1.2
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuma-ui/webpack-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "🐻 Kuma UI is a utility-first, zero-runtime CSS-in-JS library that offers an outstanding developer experience and optimized performance.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR includes two major changes:

1. It fixes an issue where `fontWeight` property was outputting as `font-weight: 600px;` instead of `font-weight: 600;` when the type of given prop is `number`. Now, both numbers and strings can be used with the fontWeight property.

2. It adds the CSS property `text-decoration` to the list of Style Props.