### PR TITLE
Remove dependency on @babel-preset/env from Next.js plugin

### DIFF
--- a/example/next-app-router/src/app/layout.tsx
+++ b/example/next-app-router/src/app/layout.tsx
@@ -1,4 +1,7 @@
-import type { FC, ReactNode } from 'react';
+import type { FC, ReactNode } from "react";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
 
 type Props = {
   children?: ReactNode;

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -80,7 +80,6 @@ const kumaUiConfig = (
             loader: "babel-loader",
             options: {
               presets: [
-                "@babel/preset-env",
                 "@babel/preset-typescript",
                 [
                   "@babel/preset-react",


### PR DESCRIPTION
I have removed the dependency on `@babel-preset/env` from the Kuma UI Next.js plugin. This resolves an issue where `const` variables were being unnecessarily transpiled to `var`.

The problem becomes evident when using Next.js's font loader, which expects the loaded font to be assigned to a `const`. When our plugin transpiled `const` to `var`, it resulted in an error: 
```sh
next-app-router:build:   x Font loader calls must be assigned to a const
next-app-router:build:    ,-[/Users/keitafuruse/development/kuma-ui/example/next-app-router/src/app/layout.tsx:1:1]
next-app-router:build:  1 |     import React from "react";
next-app-router:build:  2 |     import { Inter } from "next/font/google";
next-app-router:build:  3 | ,-> var inter = Inter({
next-app-router:build:  4 | |     subsets: ["latin"]
next-app-router:build:  5 | `-> });
next-app-router:build:  6 |     var Layout = function Layout(_ref) {
next-app-router:build:  7 |       var children = _ref.children;
next-app-router:build:  8 |       return /*#__PURE__*/React.createElement("html", null, /*#__PURE__*/React.createElement("head", null, /*#__PURE__*/React.createElement("title", null)), /*#__PURE__*/React.createElement("body", null, children));
```