### PR TITLE
Fix Overwriting of Existing ClassNames in Kuma UI

### DIFF
--- a/example/next-app-router/src/app/layout.tsx
+++ b/example/next-app-router/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { FC, ReactNode } from "react";
 import { Inter } from "next/font/google";
+import { k } from "@kuma-ui/core";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -13,7 +14,11 @@ const Layout: FC<Props> = ({ children }) => {
       <head>
         <title></title>
       </head>
-      <body>{children}</body>
+      <body>
+        <k.div bg={'red'} className={inter.className}>
+          {children}
+        </k.div>
+      </body>
     </html>
   );
 };

--- a/packages/babel-plugin/src/extractStyleProps/fromJSX.ts
+++ b/packages/babel-plugin/src/extractStyleProps/fromJSX.ts
@@ -10,7 +10,7 @@ export function extractStylePropsFromJSX(
     {};
   const pseudoProps: PseudoProps = {};
 
-  const filteredAttributes = openingElement.attributes.filter((attr) => {
+  const filteredAttributes = (openingElement.attributes.filter((attr) => {
     if (
       t.isJSXAttribute(attr) &&
       t.isJSXIdentifier(attr.name) &&
@@ -46,7 +46,7 @@ export function extractStylePropsFromJSX(
       return false;
     }
     return true;
-  }) as t.JSXAttribute[];
+  }) || []) as t.JSXAttribute[];
 
   return { filteredAttributes, styledProps, pseudoProps };
 }

--- a/packages/babel-plugin/src/extractStyleProps/fromObject.ts
+++ b/packages/babel-plugin/src/extractStyleProps/fromObject.ts
@@ -11,7 +11,7 @@ export function extractStylePropsFromObjectExpression(
     {};
   const pseudoProps: PseudoProps = {};
 
-  const filteredProperties = objectExpression.properties?.filter((prop) => {
+  const filteredProperties = (objectExpression.properties?.filter((prop) => {
     if (
       t.isObjectProperty(prop) &&
       t.isIdentifier(prop.key) &&
@@ -129,7 +129,7 @@ export function extractStylePropsFromObjectExpression(
       return false;
     }
     return true;
-  }) as t.ObjectProperty[];
+  }) || []) as t.ObjectProperty[];
 
   return { filteredProperties, styledProps, pseudoProps };
 }

--- a/packages/babel-plugin/src/processHTMLTag.ts
+++ b/packages/babel-plugin/src/processHTMLTag.ts
@@ -62,7 +62,9 @@ const processJSXHTMLTag = (path: NodePath<t.JSXOpeningElement>) => {
         return attr.value;
       }
     }
-
+    // Combine existing and new classNames. This respects user-specified class names
+    // and works with non-StringLiterals, as they'll be resolved at runtime.
+    // E.g., <k.div className={styles.someClass} fontSize={24} /> keeps both classes.
     path.node.attributes.push(
       // className={["kuma-*", defaultClassNameValue].join(' ')}
       t.jsxAttribute(

--- a/packages/babel-plugin/src/processHTMLTag.ts
+++ b/packages/babel-plugin/src/processHTMLTag.ts
@@ -66,7 +66,6 @@ const processJSXHTMLTag = (path: NodePath<t.JSXOpeningElement>) => {
     // and works with non-StringLiterals, as they'll be resolved at runtime.
     // E.g., <k.div className={styles.someClass} fontSize={24} /> keeps both classes.
     path.node.attributes.push(
-      // className={["kuma-*", defaultClassNameValue].join(' ')}
       t.jsxAttribute(
         t.jsxIdentifier("className"),
         t.jSXExpressionContainer(


### PR DESCRIPTION
#59 another plan

before
```ts
<k.div bg={'red'} className={inter.className}>
```
After
```ts
<k.div className={['kuma-*',  inter.className].join(" ")}>
```