### PR TITLE
Refactor Background Property

### DIFF
--- a/packages/system/src/color.ts
+++ b/packages/system/src/color.ts
@@ -7,12 +7,17 @@ export type ColorProps = Partial<
     /**
      * @see backgroundColor
      */
-    bg: CSSValue<"backgroundColor">;
+    bg: CSSValue<"background">;
+    /**
+     * @see backgroundColor
+     */
+    bgColor: CSSValue<"backgroundColor">;
   } & CSSProperties<"borderColor" | "color">
 >;
 
 const colorMappings: Record<ColorKeys, string> = {
-  bg: "background-color",
+  bg: "background",
+  bgColor: "ackground-color",
   color: "color",
   borderColor: "border-color",
 };

--- a/packages/system/src/color.ts
+++ b/packages/system/src/color.ts
@@ -5,7 +5,7 @@ import { applyResponsiveStyles } from "./responsive";
 export type ColorProps = Partial<
   {
     /**
-     * @see backgroundColor
+     * @see background
      */
     bg: CSSValue<"background">;
     /**

--- a/packages/system/src/compose.test.ts
+++ b/packages/system/src/compose.test.ts
@@ -33,7 +33,7 @@ describe("compose function", () => {
     expect(styles.base).toContain("margin: 8px");
     expect(styles.base).toContain("font-size: 16px");
     expect(styles.base).toContain("width: 100%");
-    expect(styles.base).toContain("background-color: red");
+    expect(styles.base).toContain("background: red");
     expect(styles.base).toContain("flex-direction: column");
     expect(styles.base).toContain(
       "box-shadow: 12px 12px 2px 1px rgba(0, 0, 255, .2)"

--- a/packages/system/src/keys.ts
+++ b/packages/system/src/keys.ts
@@ -47,7 +47,7 @@ export const styleKeys = {
     "flexBasis",
     "gap",
   ] as const,
-  color: ["bg", "color", "borderColor"] as const,
+  color: ["bg", "bgColor", "color", "borderColor"] as const,
   border: [
     "borderWidth",
     "borderStyle",


### PR DESCRIPTION
Previously, the `bg` prop was converted to `background-color`. We have now introduced a new `bgColor` prop for setting the background color specifically, and have repurposed the `bg` prop to correspond to the `background'`CSS property.