### PR TITLE
Add 'effect' props for transform and transition styles

### DIFF
--- a/packages/babel-plugin/src/processHTMLTag.ts
+++ b/packages/babel-plugin/src/processHTMLTag.ts
@@ -2,7 +2,7 @@ import { NodePath, types as t } from "@babel/core";
 import { extractStyleProps } from "./extractStyleProps";
 import { sheet } from "@kuma-ui/sheet";
 import { all, PseudoProps } from "@kuma-ui/system";
-import { pseudoMappings } from "@kuma-ui/system/dist/pseudo";
+import { pseudoMappings } from "@kuma-ui/system";
 
 export const processHTMLTag = (
   path: NodePath<t.JSXOpeningElement> | NodePath<t.ObjectExpression>

--- a/packages/system/src/effect.test.ts
+++ b/packages/system/src/effect.test.ts
@@ -1,0 +1,29 @@
+// animation.test.ts
+import { effect, EffectProps } from "./effect";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+describe("effects utility function", () => {
+  // Arrange
+  const testCases: Array<[EffectProps, string, string]> = [
+    [{ transition: "0.5s ease" }, "transition: 0.5s ease;", ""],
+    [{ transform: "scale(1.2)" }, "transform: scale(1.2);", ""],
+  ];
+
+  test.each(testCases)(
+    "should return the correct CSS styles for the given EffectsProps",
+    (props, expectedStyles, expectedMediaStyle) => {
+      // Act
+      const styles = effect(props);
+      const mediaString = Object.entries(styles.media)
+        .map(
+          ([breakpoint, css]) => `@media (min-width: ${breakpoint}) {${css}}`
+        )
+        .join("");
+      // Asert
+      expect(styles.base.replace(/\s/g, "")).toBe(
+        expectedStyles.replace(/\s/g, "")
+      );
+      expect(mediaString.replace(/\s/g, "")).toBe(expectedMediaStyle);
+    }
+  );
+});

--- a/packages/system/src/effect.ts
+++ b/packages/system/src/effect.ts
@@ -1,0 +1,44 @@
+import { EffectKeys } from "./keys";
+import { CSSProperties, CSSValue, ResponsiveStyle } from "./types";
+import { applyResponsiveStyles } from "./responsive";
+
+export type EffectProps = Partial<
+  CSSProperties<
+    | "transition"
+    | "transitionDuration"
+    | "transitionProperty"
+    | "transitionTimingFunction"
+    | "transitionDelay"
+    | "transform"
+    | "transformOrigin"
+  >
+>;
+
+const effectMappings: Record<EffectKeys, string> = {
+  transition: "transition",
+  transitionDuration: "transition-duration",
+  transitionProperty: "transition-property",
+  transitionTimingFunction: "transition-timing-function",
+  transitionDelay: "transition-delay",
+  transform: "transform",
+  transformOrigin: "transform-origin",
+} as const;
+
+export const effect = (props: EffectProps): ResponsiveStyle => {
+  let base = "";
+  const media: ResponsiveStyle["media"] = {};
+
+  for (const key in effectMappings) {
+    const cssValue = props[key as EffectKeys];
+    if (cssValue) {
+      const property = effectMappings[key as EffectKeys];
+      const responsiveStyles = applyResponsiveStyles(property, cssValue);
+      base += responsiveStyles.base;
+      for (const [breakpoint, css] of Object.entries(responsiveStyles.media)) {
+        if (media[breakpoint]) media[breakpoint] += css;
+        else media[breakpoint] = css;
+      }
+    }
+  }
+  return { base, media };
+};

--- a/packages/system/src/keys.ts
+++ b/packages/system/src/keys.ts
@@ -60,6 +60,12 @@ export const styleKeys = {
   ] as const,
   position: ["top", "right", "bottom", "left", "inset"] as const,
   shadow: ["textShadow", "boxShadow"] as const,
+  list: [
+    "listStyle",
+    "listStyleImage",
+    "listStylePosition",
+    "listStyleType",
+  ] as const,
   grid: [
     "grid",
     "gridArea",
@@ -80,11 +86,14 @@ export const styleKeys = {
     "gridColumnGap",
     "gridRowGap",
   ] as const,
-  list: [
-    "listStyle",
-    "listStyleImage",
-    "listStylePosition",
-    "listStyleType",
+  effect: [
+    "transition",
+    "transitionDuration",
+    "transitionProperty",
+    "transitionTimingFunction",
+    "transitionDelay",
+    "transform",
+    "transformOrigin",
   ] as const,
 };
 
@@ -97,8 +106,9 @@ export type BorderKeys = (typeof styleKeys.border)[number];
 export type PositionKeys = (typeof styleKeys.position)[number];
 export type ShadowKeys = (typeof styleKeys.shadow)[number];
 export type ListKeys = (typeof styleKeys.list)[number];
-
 export type GridKeys = (typeof styleKeys.grid)[number];
+
+export type EffectKeys = (typeof styleKeys.effect)[number];
 
 export type StyledKeyType =
   | SpaceKeys
@@ -110,7 +120,8 @@ export type StyledKeyType =
   | PositionKeys
   | ShadowKeys
   | ListKeys
-  | GridKeys;
+  | GridKeys
+  | EffectKeys;
 
 export const isStyledProp = (_prop: string): _prop is StyledKeyType => {
   const prop = _prop as StyledKeyType;


### PR DESCRIPTION
This PR extends prop system to support `transform` and `transition` CSS properties.