### PR TITLE
throw an error when accessing any property of 'k' at runtime

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "build": "tsup --config ../../tsup.config.ts",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit --composite false",
     "lint": "eslint './src/**/*.{js,ts,jsx,tsx}'",
     "lint:fix": "eslint --fix './src/**/*.{js,ts,jsx,tsx}'"
@@ -31,7 +32,9 @@
     "@kuma-ui/system": "workspace:*"
   },
   "devDependencies": {
-    "@types/react": "^18.0.32"
+    "@types/react": "^18.0.32",
+    "@vitest/coverage-c8": "^0.31.4",
+    "vitest": "^0.31.4"
   },
   "peerDependencies": {
     "@types/react": "^18.0.32",

--- a/packages/core/src/css.test.ts
+++ b/packages/core/src/css.test.ts
@@ -1,0 +1,10 @@
+import { css } from "./css";
+import { describe, expect, test } from "vitest";
+
+describe("css", () => {
+  test('should throw an error when using the "css" at runtime', () => {
+    expect(() => css({})).toThrowError(
+      'Using the "css" in runtime is not supported.'
+    );
+  });
+});

--- a/packages/core/src/k.test.ts
+++ b/packages/core/src/k.test.ts
@@ -1,0 +1,10 @@
+import { k } from "./k";
+import { describe, expect, test } from "vitest";
+
+describe("k", () => {
+  test(`should throw an error when using the "k" at runtime`, () => {
+    expect(() => k.div).toThrowError(
+      'Using the "k" in runtime is not supported.'
+    );
+  });
+});

--- a/packages/core/src/k.ts
+++ b/packages/core/src/k.ts
@@ -9,6 +9,13 @@ type StyledComponent<T extends keyof JSX.IntrinsicElements> = React.FC<
 
 const k: {
   [K in keyof JSX.IntrinsicElements]: StyledComponent<K>;
-} = Error('Using the "k" in runtime is not supported.') as any;
+} = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error('Using the "k" in runtime is not supported.');
+    },
+  }
+) as any;
 
 export { k };

--- a/packages/core/src/styled.test.ts
+++ b/packages/core/src/styled.test.ts
@@ -1,0 +1,10 @@
+import { styled } from "./styled";
+import { describe, expect, test } from "vitest";
+
+describe("styled", () => {
+  test('should throw an error when using the "styled" tag at runtime', () => {
+    expect(() => styled("div")``).toThrowError(
+      'Using the "styled" tag in runtime is not supported.'
+    );
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,3 @@
+import { configShared } from "../../vitest.shared";
+
+export default configShared;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,12 @@ importers:
       '@types/react':
         specifier: ^18.0.32
         version: 18.0.32
+      '@vitest/coverage-c8':
+        specifier: ^0.31.4
+        version: 0.31.4(vitest@0.31.4)
+      vitest:
+        specifier: ^0.31.4
+        version: 0.31.4
 
   packages/next-plugin:
     dependencies:


### PR DESCRIPTION
fixes the issue where an error was not being thrown when accessing properties of the `k`.

As is:

![スクリーンショット 2023-06-05 19 38 17](https://github.com/poteboy/kuma-ui/assets/12913947/82665f5f-ade4-4bb6-9b6a-f3fed07d98a6)

To be:

![スクリーンショット 2023-06-05 19 36 25](https://github.com/poteboy/kuma-ui/assets/12913947/1bd3981b-ba0f-4449-838d-4129646363ea)

