### PR TITLE
test(babel-plugin): add k api test

### DIFF
--- a/.changeset/lovely-radios-thank.md
+++ b/.changeset/lovely-radios-thank.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/babel-plugin": patch
+---
+
+test(babel-plugin): add k api test

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`k api > Snapshot tests > basic usage should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-1119741946\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using pseudo elements should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-110275621\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using pseudo props should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-110275621\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using responsive props should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-4054065355\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using space props should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-110275621\\"].join(\\" \\")
+  });
+}"
+`;

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -24,7 +24,7 @@ exports[`k api > Snapshot tests > using pseudo props should match snapshot 1`] =
 "import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
-  return /*#__PURE__*/React.createElement(\\"div\\", {
+  return /*#__PURE__*/React.createElement(\\"span\\", {
     className: [\\"kuma-110275621\\"].join(\\" \\")
   });
 }"
@@ -34,7 +34,7 @@ exports[`k api > Snapshot tests > using responsive props should match snapshot 1
 "import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
-  return /*#__PURE__*/React.createElement(\\"div\\", {
+  return /*#__PURE__*/React.createElement(\\"a\\", {
     className: [\\"kuma-4054065355\\"].join(\\" \\")
   });
 }"

--- a/packages/babel-plugin/src/__test__/k.test.ts
+++ b/packages/babel-plugin/src/__test__/k.test.ts
@@ -1,0 +1,75 @@
+import { babelTransform } from "./testUtils";
+
+describe("k api", () => {
+  describe("Snapshot tests", () => {
+    test("basic usage should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.div fontSize={24}></k.div>
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using responsive props should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.a fontSize={[16, 24]} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using space props should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.div p={2} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using pseudo elements should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.div p={2} _after={{ color: 'blue' }} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using pseudo props should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.span p={2} _hover={{ color: 'red' }} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/babel-plugin/src/__test__/testUtils.ts
+++ b/packages/babel-plugin/src/__test__/testUtils.ts
@@ -1,4 +1,4 @@
-import { transformSync } from "@babel/core";
+import { BabelFileResult, transformSync } from "@babel/core";
 import plugin from "../";
 import { types, template } from "@babel/core";
 
@@ -6,8 +6,9 @@ export function babelTransform(
   code: string,
   runtime: "classic" | "automatic" = "classic"
 ) {
-  const result = transformSync(code, {
-    plugins: [plugin({ types, template })],
+  const filename = "test.tsx";
+  let result: BabelFileResult | null = null;
+  result = transformSync(code, {
     presets: [
       "@babel/preset-typescript",
       [
@@ -17,10 +18,18 @@ export function babelTransform(
         },
       ],
     ],
-    filename: "test.tsx",
+    filename,
   });
 
-  if (result === null || result.code === null)
+  if (result === null || result.code == null)
+    throw new Error(`Could not transform`);
+
+  result = transformSync(result.code, {
+    plugins: [plugin({ types, template })],
+    filename,
+  });
+
+  if (result === null || result.code == null)
     throw new Error(`Could not transform`);
 
   return { result: result, code: result.code };


### PR DESCRIPTION
I added tests for the `k` API, which didn't exist before.
This makes it easier to debug babel plugin and ensures a certain level of quality.