### PR TITLE
test(babel-plugin): add generated css to snapshots

### DIFF
--- a/.changeset/stale-pigs-call.md
+++ b/.changeset/stale-pigs-call.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/babel-plugin": patch
+---
+
+test(babel-plugin): add generated css to snapshots

--- a/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
@@ -1,25 +1,41 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`css function > Snapshot tests > basic usage should match snapshot 1`] = `
+
+.kuma-3383855968 {color:red;}
+
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-3383855968";
+
 `;
 
 exports[`css function > Snapshot tests > using pseudo elements should match snapshot 1`] = `
+
+.kuma-1234644783 {}.kuma-1234644783:after{color:blue;}
+
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-1234644783";
+
 `;
 
 exports[`css function > Snapshot tests > using pseudo props should match snapshot 1`] = `
+
+.kuma-1234644783 {}.kuma-1234644783:hover{color:red;}
+
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-1234644783";
+
 `;
 
 exports[`css function > Snapshot tests > using space props should match snapshot 1`] = `
+
+.kuma-110275621 {padding:2px;}
+
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-110275621";
+
 `;

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -1,51 +1,71 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`k api > Snapshot tests > basic usage should match snapshot 1`] = `
-"import React from \\"react\\";
+"
+.kuma-1119741946 {font-size:24px;}
+
+import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return /*#__PURE__*/React.createElement(\\"div\\", {
     className: [\\"kuma-1119741946\\"].join(\\" \\")
   });
-}"
+}
+"
 `;
 
 exports[`k api > Snapshot tests > using pseudo elements should match snapshot 1`] = `
-"import React from \\"react\\";
+"
+.kuma-110275621 {padding:2px;}.kuma-110275621:after{color:blue;}
+
+import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return /*#__PURE__*/React.createElement(\\"div\\", {
     className: [\\"kuma-110275621\\"].join(\\" \\")
   });
-}"
+}
+"
 `;
 
 exports[`k api > Snapshot tests > using pseudo props should match snapshot 1`] = `
-"import React from \\"react\\";
+"
+.kuma-110275621 {padding:2px;}.kuma-110275621:hover{color:red;}
+
+import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return /*#__PURE__*/React.createElement(\\"span\\", {
     className: [\\"kuma-110275621\\"].join(\\" \\")
   });
-}"
+}
+"
 `;
 
 exports[`k api > Snapshot tests > using responsive props should match snapshot 1`] = `
-"import React from \\"react\\";
+"
+.kuma-4054065355 {font-size:16px;}@media (min-width:576px){.kuma-4054065355{font-size:24px;}}
+
+import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return /*#__PURE__*/React.createElement(\\"a\\", {
     className: [\\"kuma-4054065355\\"].join(\\" \\")
   });
-}"
+}
+"
 `;
 
 exports[`k api > Snapshot tests > using space props should match snapshot 1`] = `
-"import React from \\"react\\";
+"
+.kuma-110275621 {padding:2px;}
+
+import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
   return /*#__PURE__*/React.createElement(\\"div\\", {
     className: [\\"kuma-110275621\\"].join(\\" \\")
   });
-}"
+}
+"
 `;

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`k api > Snapshot tests > basic usage should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-1119741946\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using pseudo elements should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-110275621\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using pseudo props should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-110275621\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using responsive props should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-4054065355\\"].join(\\" \\")
+  });
+}"
+`;
+
+exports[`k api > Snapshot tests > using space props should match snapshot 1`] = `
+"import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App() {
+  return /*#__PURE__*/React.createElement(\\"div\\", {
+    className: [\\"kuma-110275621\\"].join(\\" \\")
+  });
+}"
+`;

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -24,7 +24,7 @@ exports[`k api > Snapshot tests > using pseudo props should match snapshot 1`] =
 "import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
-  return /*#__PURE__*/React.createElement(\\"div\\", {
+  return /*#__PURE__*/React.createElement(\\"span\\", {
     className: [\\"kuma-110275621\\"].join(\\" \\")
   });
 }"
@@ -34,7 +34,7 @@ exports[`k api > Snapshot tests > using responsive props should match snapshot 1
 "import React from \\"react\\";
 import { k } from '@kuma-ui/core';
 function App() {
-  return /*#__PURE__*/React.createElement(\\"div\\", {
+  return /*#__PURE__*/React.createElement(\\"a\\", {
     className: [\\"kuma-4054065355\\"].join(\\" \\")
   });
 }"

--- a/packages/babel-plugin/src/__test__/css.test.ts
+++ b/packages/babel-plugin/src/__test__/css.test.ts
@@ -1,7 +1,7 @@
 // for babel-plugin-tester; see: https://github.com/babel-utils/babel-plugin-tester#vitest
 /// <reference types="vitest/globals" />
 
-import { babelTransform } from "./testUtils";
+import { babelTransform, getExpectSnapshot } from "./testUtils";
 import { pluginTester } from "babel-plugin-tester";
 import { types, template } from "@babel/core";
 import plugin from "../";
@@ -16,9 +16,9 @@ describe("css function", () => {
         const style = css({ color: 'red' })
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
 
     test("using space props should match snapshot", () => {
@@ -28,9 +28,9 @@ describe("css function", () => {
         const style = css({ p: 2 })
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
 
     test("using pseudo elements should match snapshot", () => {
@@ -40,9 +40,9 @@ describe("css function", () => {
         const style = css({ _after: { color: 'blue' } })
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
 
     test("using pseudo props should match snapshot", () => {
@@ -52,9 +52,9 @@ describe("css function", () => {
         const style = css({ _hover: { color: 'red' } })
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
   });
 });

--- a/packages/babel-plugin/src/__test__/k.test.ts
+++ b/packages/babel-plugin/src/__test__/k.test.ts
@@ -1,4 +1,4 @@
-import { babelTransform } from "./testUtils";
+import { babelTransform, getExpectSnapshot } from "./testUtils";
 
 describe("k api", () => {
   describe("Snapshot tests", () => {
@@ -11,9 +11,9 @@ describe("k api", () => {
         }
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
 
     test("using responsive props should match snapshot", () => {
@@ -25,9 +25,9 @@ describe("k api", () => {
         }
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
 
     test("using space props should match snapshot", () => {
@@ -39,9 +39,9 @@ describe("k api", () => {
         }
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
 
     test("using pseudo elements should match snapshot", () => {
@@ -53,9 +53,9 @@ describe("k api", () => {
         }
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
 
     test("using pseudo props should match snapshot", () => {
@@ -67,9 +67,9 @@ describe("k api", () => {
         }
       `;
       // Act
-      const { code } = babelTransform(inputCode);
+      const result = babelTransform(inputCode);
       // Assert
-      expect(code).toMatchSnapshot();
+      expect(getExpectSnapshot(result)).toMatchSnapshot();
     });
   });
 });

--- a/packages/babel-plugin/src/__test__/k.test.ts
+++ b/packages/babel-plugin/src/__test__/k.test.ts
@@ -1,0 +1,75 @@
+import { babelTransform } from "./testUtils";
+
+describe("k api", () => {
+  describe("Snapshot tests", () => {
+    test("basic usage should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.div fontSize={24}></k.div>
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using responsive props should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.a fontSize={[16, 24]} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using space props should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.div p={2} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using pseudo elements should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.div p={2} _after={{ color: 'blue' }} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+
+    test("using pseudo props should match snapshot", () => {
+      // Arrange
+      const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App() {
+          return <k.span p={2} _hover={{ color: 'red' }} />
+        }
+      `;
+      // Act
+      const { code } = babelTransform(inputCode);
+      // Assert
+      expect(code).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/babel-plugin/src/__test__/testUtils.ts
+++ b/packages/babel-plugin/src/__test__/testUtils.ts
@@ -32,5 +32,13 @@ export function babelTransform(
   if (result === null || result.code == null)
     throw new Error(`Could not transform`);
 
-  return { result: result, code: result.code };
+  return result;
+}
+
+export function getExpectSnapshot(result: BabelFileResult) {
+  return `
+${(result.metadata as { css: string } | undefined)?.css}
+
+${result.code}
+`;
 }

--- a/packages/babel-plugin/src/__test__/testUtils.ts
+++ b/packages/babel-plugin/src/__test__/testUtils.ts
@@ -1,4 +1,4 @@
-import { transformSync } from "@babel/core";
+import { BabelFileResult, transformSync } from "@babel/core";
 import plugin from "../";
 import { types, template } from "@babel/core";
 
@@ -6,8 +6,9 @@ export function babelTransform(
   code: string,
   runtime: "classic" | "automatic" = "classic"
 ) {
-  const result = transformSync(code, {
-    plugins: [plugin({ types, template })],
+  const filename = "test.tsx";
+  let result: BabelFileResult | null = null;
+  result = transformSync(code, {
     presets: [
       "@babel/preset-typescript",
       [
@@ -17,10 +18,18 @@ export function babelTransform(
         },
       ],
     ],
-    filename: "test.tsx",
+    filename,
   });
 
-  if (result === null || result.code === null)
+  if (result === null || result.code == null)
+    throw new Error(`Could not transform`);
+
+  result = transformSync(result.code, {
+    plugins: [plugin({ types, template })],
+    filename,
+  });
+
+  if (result === null || result.code == null)
     throw new Error(`Could not transform`);
 
   return { result: result, code: result.code };


### PR DESCRIPTION
I have made improvements to include styles containing class names generated by the Babel plugin in the snapshots.
This ensures the quality of the style generation logic.

The changes I made are as follows:

- Modified to return the result of `transformSync` directly in `babelTransform`.
- Created a `getExpectSnapshot` function to generate the expected snapshot value containing the generated css from the return value of `transformSync`.

Since I checked out from the branch of https://github.com/poteboy/kuma-ui/pull/102, I would like you to merge this PR after merging that PR :pray: