### PR TITLE
Refactor to improve JSX transformation functions

### DIFF
--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -1,4 +1,13 @@
-import { Box, Flex, Spacer, Text, Button, Heading } from "@kuma-ui/core";
+import {
+  Box,
+  Flex,
+  Spacer,
+  Text,
+  Button,
+  Heading,
+  styled,
+  k,
+} from "@kuma-ui/core";
 
 function App() {
   return (
@@ -11,8 +20,13 @@ function App() {
         <Text>hello</Text>
         <Button>hello</Button>
       </Flex>
+      <HelloWorld>hello world</HelloWorld>
     </Box>
   );
 }
+
+const HelloWorld = styled("p")`
+  color: red;
+`;
 
 export default App;

--- a/packages/babel-plugin/src/__test__/__fixtures__/base/output.js
+++ b/packages/babel-plugin/src/__test__/__fixtures__/base/output.js
@@ -1,3 +1,4 @@
+import { Box as __Box } from "@kuma-ui/core";
 import React from "react";
 import { css } from "@kuma-ui/core";
 const style = "kuma-3206633536";

--- a/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/css.test.ts.snap
@@ -4,6 +4,7 @@ exports[`css function > Snapshot tests > basic usage should match snapshot 1`] =
 
 .kuma-944610715{color:red;}
 
+import { Box as __Box } from "@kuma-ui/core";
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-944610715";
@@ -14,6 +15,7 @@ exports[`css function > Snapshot tests > using pseudo elements should match snap
 
 .kuma-3353610691{}.kuma-3353610691:after{color:blue;}
 
+import { Box as __Box } from "@kuma-ui/core";
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-3353610691";
@@ -24,6 +26,7 @@ exports[`css function > Snapshot tests > using pseudo props should match snapsho
 
 .kuma-400375226{}.kuma-400375226:hover{color:red;}
 
+import { Box as __Box } from "@kuma-ui/core";
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-400375226";
@@ -34,6 +37,7 @@ exports[`css function > Snapshot tests > using space props should match snapshot
 
 .kuma-3206633536{padding:2px;}
 
+import { Box as __Box } from "@kuma-ui/core";
 import React from "react";
 import { css } from '@kuma-ui/core';
 const style = "kuma-3206633536";

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -4,13 +4,15 @@ exports[`styled function > Snapshot tests (runtime: automatic) > basic usage sho
 "
 .kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { jsx as _jsx } from \\"react/jsx-runtime\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(\\"div\\", {
+  return /*#__PURE__*/_jsx(__Box, {
+    as: \\"div\\",
     ...props,
     className: combinedClassName
   });
@@ -27,13 +29,15 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using className
 "
 .kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { jsx as _jsx } from \\"react/jsx-runtime\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(\\"span\\", {
+  return /*#__PURE__*/_jsx(__Box, {
+    as: \\"span\\",
     ...props,
     className: combinedClassName
   });
@@ -51,13 +55,15 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using pseudo el
 "
 .kuma-2631981251{padding:2px;}.kuma-2631981251:after{color:blue;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { jsx as _jsx } from \\"react/jsx-runtime\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(\\"div\\", {
+  return /*#__PURE__*/_jsx(__Box, {
+    as: \\"div\\",
     ...props,
     className: combinedClassName
   });
@@ -75,13 +81,15 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using pseudo pr
 "
 .kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { jsx as _jsx } from \\"react/jsx-runtime\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(\\"span\\", {
+  return /*#__PURE__*/_jsx(__Box, {
+    as: \\"span\\",
     ...props,
     className: combinedClassName
   });
@@ -99,13 +107,15 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using responsiv
 "
 .kuma-401969115{font-size:16px;}@media (min-width:576px){.kuma-401969115{font-size:24px;}}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { jsx as _jsx } from \\"react/jsx-runtime\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(\\"a\\", {
+  return /*#__PURE__*/_jsx(__Box, {
+    as: \\"a\\",
     ...props,
     className: combinedClassName
   });
@@ -123,13 +133,15 @@ exports[`styled function > Snapshot tests (runtime: automatic) > using space pro
 "
 .kuma-3206633536{padding:2px;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { jsx as _jsx } from \\"react/jsx-runtime\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(\\"div\\", {
+  return /*#__PURE__*/_jsx(__Box, {
+    as: \\"div\\",
     ...props,
     className: combinedClassName
   });
@@ -148,12 +160,15 @@ exports[`styled function > Snapshot tests (runtime: classic) > basic usage shoul
 .kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(\\"div\\", _extends({}, props, {
+  return /*#__PURE__*/React.createElement(__Box, _extends({
+    as: \\"div\\"
+  }, props, {
     className: combinedClassName
   }));
 };
@@ -168,12 +183,15 @@ exports[`styled function > Snapshot tests (runtime: classic) > using className p
 .kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(\\"span\\", _extends({}, props, {
+  return /*#__PURE__*/React.createElement(__Box, _extends({
+    as: \\"span\\"
+  }, props, {
     className: combinedClassName
   }));
 };
@@ -190,12 +208,15 @@ exports[`styled function > Snapshot tests (runtime: classic) > using pseudo elem
 .kuma-2631981251{padding:2px;}.kuma-2631981251:after{color:blue;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(\\"div\\", _extends({}, props, {
+  return /*#__PURE__*/React.createElement(__Box, _extends({
+    as: \\"div\\"
+  }, props, {
     className: combinedClassName
   }));
 };
@@ -212,12 +233,15 @@ exports[`styled function > Snapshot tests (runtime: classic) > using pseudo prop
 .kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(\\"span\\", _extends({}, props, {
+  return /*#__PURE__*/React.createElement(__Box, _extends({
+    as: \\"span\\"
+  }, props, {
     className: combinedClassName
   }));
 };
@@ -234,12 +258,15 @@ exports[`styled function > Snapshot tests (runtime: classic) > using responsive 
 .kuma-401969115{font-size:16px;}@media (min-width:576px){.kuma-401969115{font-size:24px;}}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(\\"a\\", _extends({}, props, {
+  return /*#__PURE__*/React.createElement(__Box, _extends({
+    as: \\"a\\"
+  }, props, {
     className: combinedClassName
   }));
 };
@@ -256,12 +283,15 @@ exports[`styled function > Snapshot tests (runtime: classic) > using space props
 .kuma-3206633536{padding:2px;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(\\"div\\", _extends({}, props, {
+  return /*#__PURE__*/React.createElement(__Box, _extends({
+    as: \\"div\\"
+  }, props, {
     className: combinedClassName
   }));
 };
@@ -284,7 +314,7 @@ const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <div {...props} className={combinedClassName} />;
+  return <__Box as=\\"div\\" {...props} className={combinedClassName} />;
 };
 function App() {
   return <Box>test</Box>;
@@ -303,7 +333,7 @@ const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <span {...props} className={combinedClassName} />;
+  return <__Box as=\\"span\\" {...props} className={combinedClassName} />;
 };
 function App() {
   return <Box className={[\\"kuma-2131929892\\", \\"kuma-1440123820\\"].join(\\" \\")}>
@@ -324,7 +354,7 @@ const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <div {...props} className={combinedClassName} />;
+  return <__Box as=\\"div\\" {...props} className={combinedClassName} />;
 };
 function App() {
   return <Box className=\\"kuma-2631981251\\">test</Box>;
@@ -343,7 +373,7 @@ const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <span {...props} className={combinedClassName} />;
+  return <__Box as=\\"span\\" {...props} className={combinedClassName} />;
 };
 function App() {
   return <Box className=\\"kuma-2131929892\\">test</Box>;
@@ -362,7 +392,7 @@ const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <a {...props} className={combinedClassName} />;
+  return <__Box as=\\"a\\" {...props} className={combinedClassName} />;
 };
 function App() {
   return <Box className=\\"kuma-401969115\\">test</Box>;
@@ -381,7 +411,7 @@ const Box = props => {
   const existingClassName = props.className || \\"\\";
   const newClassName = \\"kuma-686274543\\";
   const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <div {...props} className={combinedClassName} />;
+  return <__Box as=\\"div\\" {...props} className={combinedClassName} />;
 };
 function App() {
   return <Box className=\\"kuma-3206633536\\">test</Box>;

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -277,6 +277,7 @@ exports[`styled function > Snapshot tests (runtime: undefined) > basic usage sho
 "
 .kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
@@ -295,6 +296,7 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using className
 "
 .kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled, css } from '@kuma-ui/core';
 const Box = props => {
@@ -315,6 +317,7 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using pseudo el
 "
 .kuma-2631981251{padding:2px;}.kuma-2631981251:after{color:blue;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
@@ -333,6 +336,7 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using pseudo pr
 "
 .kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
@@ -351,6 +355,7 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using responsiv
 "
 .kuma-401969115{font-size:16px;}@media (min-width:576px){.kuma-401969115{font-size:24px;}}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {
@@ -369,6 +374,7 @@ exports[`styled function > Snapshot tests (runtime: undefined) > using space pro
 "
 .kuma-3206633536{padding:2px;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
+import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
 import { styled } from '@kuma-ui/core';
 const Box = props => {

--- a/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/styled.test.ts.snap
@@ -27,7 +27,7 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: automatic) > using className prop should match snapshot 1`] = `
 "
-.kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
+.kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
@@ -44,7 +44,7 @@ const Box = props => {
 };
 function App() {
   return /*#__PURE__*/_jsx(Box, {
-    className: [\\"kuma-2131929892\\", \\"kuma-1440123820\\"].join(\\" \\"),
+    className: \\"kuma-1440123820\\",
     children: \\"test\\"
   });
 }
@@ -53,7 +53,7 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: automatic) > using pseudo elements should match snapshot 1`] = `
 "
-.kuma-2631981251{padding:2px;}.kuma-2631981251:after{color:blue;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
+.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
@@ -70,85 +70,6 @@ const Box = props => {
 };
 function App() {
   return /*#__PURE__*/_jsx(Box, {
-    className: \\"kuma-2631981251\\",
-    children: \\"test\\"
-  });
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: automatic) > using pseudo props should match snapshot 1`] = `
-"
-.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-import { jsx as _jsx } from \\"react/jsx-runtime\\";
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(__Box, {
-    as: \\"span\\",
-    ...props,
-    className: combinedClassName
-  });
-};
-function App() {
-  return /*#__PURE__*/_jsx(Box, {
-    className: \\"kuma-2131929892\\",
-    children: \\"test\\"
-  });
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: automatic) > using responsive props should match snapshot 1`] = `
-"
-.kuma-401969115{font-size:16px;}@media (min-width:576px){.kuma-401969115{font-size:24px;}}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-import { jsx as _jsx } from \\"react/jsx-runtime\\";
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(__Box, {
-    as: \\"a\\",
-    ...props,
-    className: combinedClassName
-  });
-};
-function App() {
-  return /*#__PURE__*/_jsx(Box, {
-    className: \\"kuma-401969115\\",
-    children: \\"test\\"
-  });
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: automatic) > using space props should match snapshot 1`] = `
-"
-.kuma-3206633536{padding:2px;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-import { jsx as _jsx } from \\"react/jsx-runtime\\";
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/_jsx(__Box, {
-    as: \\"div\\",
-    ...props,
-    className: combinedClassName
-  });
-};
-function App() {
-  return /*#__PURE__*/_jsx(Box, {
-    className: \\"kuma-3206633536\\",
     children: \\"test\\"
   });
 }
@@ -180,7 +101,7 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: classic) > using className prop should match snapshot 1`] = `
 "
-.kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
+.kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 import { Box as __Box } from \\"@kuma-ui/core\\";
@@ -197,7 +118,7 @@ const Box = props => {
 };
 function App() {
   return /*#__PURE__*/React.createElement(Box, {
-    className: [\\"kuma-2131929892\\", \\"kuma-1440123820\\"].join(\\" \\")
+    className: \\"kuma-1440123820\\"
   }, \\"test\\");
 }
 "
@@ -205,7 +126,7 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: classic) > using pseudo elements should match snapshot 1`] = `
 "
-.kuma-2631981251{padding:2px;}.kuma-2631981251:after{color:blue;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
+.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 import { Box as __Box } from \\"@kuma-ui/core\\";
@@ -221,84 +142,7 @@ const Box = props => {
   }));
 };
 function App() {
-  return /*#__PURE__*/React.createElement(Box, {
-    className: \\"kuma-2631981251\\"
-  }, \\"test\\");
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: classic) > using pseudo props should match snapshot 1`] = `
-"
-.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(__Box, _extends({
-    as: \\"span\\"
-  }, props, {
-    className: combinedClassName
-  }));
-};
-function App() {
-  return /*#__PURE__*/React.createElement(Box, {
-    className: \\"kuma-2131929892\\"
-  }, \\"test\\");
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: classic) > using responsive props should match snapshot 1`] = `
-"
-.kuma-401969115{font-size:16px;}@media (min-width:576px){.kuma-401969115{font-size:24px;}}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(__Box, _extends({
-    as: \\"a\\"
-  }, props, {
-    className: combinedClassName
-  }));
-};
-function App() {
-  return /*#__PURE__*/React.createElement(Box, {
-    className: \\"kuma-401969115\\"
-  }, \\"test\\");
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: classic) > using space props should match snapshot 1`] = `
-"
-.kuma-3206633536{padding:2px;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return /*#__PURE__*/React.createElement(__Box, _extends({
-    as: \\"div\\"
-  }, props, {
-    className: combinedClassName
-  }));
-};
-function App() {
-  return /*#__PURE__*/React.createElement(Box, {
-    className: \\"kuma-3206633536\\"
-  }, \\"test\\");
+  return /*#__PURE__*/React.createElement(Box, null, \\"test\\");
 }
 "
 `;
@@ -324,7 +168,7 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: undefined) > using className prop should match snapshot 1`] = `
 "
-.kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
+.kuma-1440123820{box-shadow:0 1px 2px 0 rgba(0, 0, 0, 0.05);}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
@@ -336,7 +180,7 @@ const Box = props => {
   return <__Box as=\\"span\\" {...props} className={combinedClassName} />;
 };
 function App() {
-  return <Box className={[\\"kuma-2131929892\\", \\"kuma-1440123820\\"].join(\\" \\")}>
+  return <Box className={\\"kuma-1440123820\\"}>
               test
             </Box>;
 }
@@ -345,7 +189,7 @@ function App() {
 
 exports[`styled function > Snapshot tests (runtime: undefined) > using pseudo elements should match snapshot 1`] = `
 "
-.kuma-2631981251{padding:2px;}.kuma-2631981251:after{color:blue;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
+.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
 
 import { Box as __Box } from \\"@kuma-ui/core\\";
 import React from \\"react\\";
@@ -357,64 +201,7 @@ const Box = props => {
   return <__Box as=\\"div\\" {...props} className={combinedClassName} />;
 };
 function App() {
-  return <Box className=\\"kuma-2631981251\\">test</Box>;
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: undefined) > using pseudo props should match snapshot 1`] = `
-"
-.kuma-2131929892{padding:2px;}.kuma-2131929892:hover{color:red;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-import { styled } from '@kuma-ui/core';
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <__Box as=\\"span\\" {...props} className={combinedClassName} />;
-};
-function App() {
-  return <Box className=\\"kuma-2131929892\\">test</Box>;
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: undefined) > using responsive props should match snapshot 1`] = `
-"
-.kuma-401969115{font-size:16px;}@media (min-width:576px){.kuma-401969115{font-size:24px;}}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-import { styled } from '@kuma-ui/core';
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <__Box as=\\"a\\" {...props} className={combinedClassName} />;
-};
-function App() {
-  return <Box className=\\"kuma-401969115\\">test</Box>;
-}
-"
-`;
-
-exports[`styled function > Snapshot tests (runtime: undefined) > using space props should match snapshot 1`] = `
-"
-.kuma-3206633536{padding:2px;}.kuma-686274543{position:relative;width:300px;height:300px;background-color:rgba(255, 0, 0, 0.5);}.kuma-686274543:hover{background-color:rgba(0, 0, 255, 0.5);}@media (max-width: 768px){.kuma-686274543{flex-direction:column;}}
-
-import { Box as __Box } from \\"@kuma-ui/core\\";
-import React from \\"react\\";
-import { styled } from '@kuma-ui/core';
-const Box = props => {
-  const existingClassName = props.className || \\"\\";
-  const newClassName = \\"kuma-686274543\\";
-  const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(\\" \\");
-  return <__Box as=\\"div\\" {...props} className={combinedClassName} />;
-};
-function App() {
-  return <Box className=\\"kuma-3206633536\\">test</Box>;
+  return <Box>test</Box>;
 }
 "
 `;

--- a/packages/babel-plugin/src/__test__/styled.test.ts
+++ b/packages/babel-plugin/src/__test__/styled.test.ts
@@ -30,58 +30,6 @@ describe("styled function", () => {
         expect(getExpectSnapshot(result)).toMatchSnapshot();
       });
 
-      test("using responsive props should match snapshot", () => {
-        // Arrange
-        const inputCode = `
-        import { styled } from '@kuma-ui/core'
-        const Box = styled('a')\`
-          position: relative;
-          width: 300px;
-          height: 300px;
-          background-color: rgba(255, 0, 0, 0.5);
-          &:hover {
-            background-color: rgba(0, 0, 255, 0.5);
-          }
-          @media (max-width: 768px) {
-            flex-direction: column;
-          }
-        \`
-        function App() {
-          return <Box fontSize={[16, 24]}>test</Box>
-        }
-      `;
-        // Act
-        const result = babelTransform(inputCode, runtime);
-        // Assert
-        expect(getExpectSnapshot(result)).toMatchSnapshot();
-      });
-
-      test("using space props should match snapshot", () => {
-        // Arrange
-        const inputCode = `
-        import { styled } from '@kuma-ui/core'
-        const Box = styled('div')\`
-          position: relative;
-          width: 300px;
-          height: 300px;
-          background-color: rgba(255, 0, 0, 0.5);
-          &:hover {
-            background-color: rgba(0, 0, 255, 0.5);
-          }
-          @media (max-width: 768px) {
-            flex-direction: column;
-          }
-        \`
-        function App() {
-          return <Box p={2}>test</Box>
-        }
-      `;
-        // Act
-        const result = babelTransform(inputCode, runtime);
-        // Assert
-        expect(getExpectSnapshot(result)).toMatchSnapshot();
-      });
-
       test("using pseudo elements should match snapshot", () => {
         // Arrange
         const inputCode = `
@@ -99,33 +47,7 @@ describe("styled function", () => {
           }
         \`
         function App() {
-          return <Box p={2} _after={{ color: 'blue' }}>test</Box>
-        }
-      `;
-        // Act
-        const result = babelTransform(inputCode, runtime);
-        // Assert
-        expect(getExpectSnapshot(result)).toMatchSnapshot();
-      });
-
-      test("using pseudo props should match snapshot", () => {
-        // Arrange
-        const inputCode = `
-        import { styled } from '@kuma-ui/core'
-        const Box = styled('span')\`
-          position: relative;
-          width: 300px;
-          height: 300px;
-          background-color: rgba(255, 0, 0, 0.5);
-          &:hover {
-            background-color: rgba(0, 0, 255, 0.5);
-          }
-          @media (max-width: 768px) {
-            flex-direction: column;
-          }
-        \`
-        function App() {
-          return <Box p={2} _hover={{ color: 'red' }}>test</Box>
+          return <Box>test</Box>
         }
       `;
         // Act
@@ -153,8 +75,6 @@ describe("styled function", () => {
         function App() {
           return (
             <Box
-              p={2}
-              _hover={{ color: 'red' }}
               className={css({ boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)' })}
             >
               test

--- a/packages/babel-plugin/src/importBox.ts
+++ b/packages/babel-plugin/src/importBox.ts
@@ -1,0 +1,25 @@
+import { NodePath, Node, types as t, template } from "@babel/core";
+
+/**
+ * If the 'Box' component is not imported, this function will create a new import statement for the 'Box' component
+ * from '@kuma-ui/core' with the local name '__Box'.
+ *
+ * @param {NodePath<types.Program>} node - The NodePath object representing the Program node.
+ * @param {Record<string, string>} importedStyleFunctions - An object containing the imported styled functions.
+ */
+export function importBox(
+  node: NodePath<t.Program>,
+  importedStyleFunctions: Record<string, string>
+) {
+  let boxName: string = importedStyleFunctions["Box"];
+  if (!boxName) {
+    const localBoxName = "__Box";
+    const reactImportDeclaration = t.importDeclaration(
+      [t.importSpecifier(t.identifier(localBoxName), t.identifier("Box"))],
+      t.stringLiteral("@kuma-ui/core")
+    );
+    node.unshiftContainer("body", reactImportDeclaration);
+    boxName = localBoxName;
+  }
+  importedStyleFunctions["Box"] = boxName;
+}

--- a/packages/babel-plugin/src/processTaggedTemplateExpression.ts
+++ b/packages/babel-plugin/src/processTaggedTemplateExpression.ts
@@ -1,5 +1,6 @@
 import { sheet } from "@kuma-ui/sheet";
-import type { NodePath, types, template as Template } from "@babel/core";
+import type { NodePath, template as Template } from "@babel/core";
+import { types as t } from "@babel/core";
 
 /**
  * Processes a TaggedTemplateExpression and creates a new React component based on the styled function.
@@ -12,8 +13,7 @@ import type { NodePath, types, template as Template } from "@babel/core";
  * @param {Record<string, string>} importedStyleFunctions - An object containing the imported styled functions.
  */
 export const processTaggedTemplateExpression = (
-  nodePath: NodePath<types.Program>,
-  t: typeof types,
+  nodePath: NodePath<t.Program>,
   template: typeof Template,
   importedStyleFunctions: Record<string, string>
 ) => {
@@ -40,8 +40,6 @@ export const processTaggedTemplateExpression = (
 
       const component = t.isStringLiteral(componentArg)
         ? componentArg.value
-        : t.isJSXElement(componentArg)
-        ? componentArg
         : "div";
       const createElementAst = template.expression.ast(
         `
@@ -50,7 +48,9 @@ export const processTaggedTemplateExpression = (
             const newClassName = "${className || ""}";
             const combinedClassName = [existingClassName, newClassName].filter(Boolean).join(" ");
             return (
-              <${component} data-kuma-ui="${true}" {...props} className={combinedClassName} />
+              <${
+                importedStyleFunctions["Box"]
+              } as="${component}" {...props} className={combinedClassName} />
             );
         }`,
         {

--- a/packages/babel-plugin/src/visitor.ts
+++ b/packages/babel-plugin/src/visitor.ts
@@ -9,6 +9,7 @@ import { replaceKwithBox } from "./replaceKwithBox";
 import { processTaggedTemplateExpression } from "./processTaggedTemplateExpression";
 import { processCSS } from "./processCSS";
 import { processComponents } from "./components/processComponents";
+import { importBox } from "./importBox";
 
 export const styledFunctionsMap = new Map<string, Node[]>();
 
@@ -27,6 +28,8 @@ export const visitor = ({ types: t, template }: Core) => {
         ensureReactImport(path, t);
         // Reset the importedStyleFunctions
         importedStyleFunctions = collectImportedStyled(path, t);
+        // Create an import statement for the 'Box' component from '@kuma-ui/core'
+        importBox(path, importedStyleFunctions);
         // Replace the 'k' function from '@kuma-ui/core' with the corresponding HTML tag
         replaceKwithBox(path, t, importedStyleFunctions);
         // Process CSS function calls and generate the hashed classNames

--- a/packages/babel-plugin/src/visitor.ts
+++ b/packages/babel-plugin/src/visitor.ts
@@ -35,12 +35,7 @@ export const visitor = ({ types: t, template }: Core) => {
         // Process CSS function calls and generate the hashed classNames
         processCSS(path, t, template, importedStyleFunctions);
         // Process TaggedTemplateExpressions with styled components and generate the hashed classNames
-        processTaggedTemplateExpression(
-          path,
-          t,
-          template,
-          importedStyleFunctions
-        );
+        processTaggedTemplateExpression(path, template, importedStyleFunctions);
         // Traversal over the JSX elements in the Program node to identify Kuma-UI components,
         processComponents(path, importedStyleFunctions);
       },

--- a/packages/core/src/styled.ts
+++ b/packages/core/src/styled.ts
@@ -22,15 +22,11 @@ export type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
  * @returns A new component with styled-system functionality and a unique data-kuma-ui attribute
  */
 function styled<T extends keyof JSX.IntrinsicElements>(Component: T) {
-  const fn = function <P = StyledProps>(
-    strings: TemplateStringsArray,
-    ...interpolations: ((props: P) => ResponsiveStyle)[]
-  ): React.FC<
-    Omit<StyledComponentProps<T>, StyledKeyType> & P & Partial<PseudoProps>
-  > {
-    throw Error('Using the "styled" tag in runtime is not supported.');
+  const fn = (
+    strings: TemplateStringsArray
+  ): React.FC<React.ComponentProps<T>> => {
+    throw Error('Using the "styled" tag in runtime is not supported.') as any;
   };
-  fn.__zeroStyled = true;
   return fn;
 }
 

--- a/packages/core/src/styled.ts
+++ b/packages/core/src/styled.ts
@@ -21,9 +21,7 @@ export type StyledComponentProps<T> = T extends keyof JSX.IntrinsicElements
  * @param Component - The component to be wrapped with styled-system functionality
  * @returns A new component with styled-system functionality and a unique data-kuma-ui attribute
  */
-function styled<T extends keyof JSX.IntrinsicElements | ComponentType<any>>(
-  Component: T
-) {
+function styled<T extends keyof JSX.IntrinsicElements>(Component: T) {
   const fn = function <P = StyledProps>(
     strings: TemplateStringsArray,
     ...interpolations: ((props: P) => ResponsiveStyle)[]


### PR DESCRIPTION
- [x] Refactored the import process for the `Box` component into a separate function named `importBox`.
- [x] Updated the `processTaggedTemplateExpression` function to return a `Box` component instead of raw HTML
- [x] Updated the JSX traversal process to only extract style props from Kuma-UI components, instead of all HTML elements.