### PR TITLE
Optimize styled prop detection using memoization

### DIFF
--- a/packages/system/src/keys.ts
+++ b/packages/system/src/keys.ts
@@ -123,9 +123,17 @@ export type StyledKeyType =
   | GridKeys
   | EffectKeys;
 
-export const isStyledProp = (_prop: string): _prop is StyledKeyType => {
+function memo<T>(fn: (value: string) => T): (value: string) => T {
+  const cache = Object.create(null);
+  return (arg: string) => {
+    if (cache[arg] === undefined) cache[arg] = fn(arg);
+    return cache[arg];
+  };
+}
+
+export const isStyledProp = memo((_prop: string): _prop is StyledKeyType => {
   const prop = _prop as StyledKeyType;
   return Object.values(styleKeys).some((keyGroup) =>
     (keyGroup as readonly string[]).includes(prop)
   );
-};
+});


### PR DESCRIPTION
Previously, we used a lookup operation with O(N) complexity to identify styled props using the `isStyledProp` function. This PR improves this by introducing memoization to cache results of previous prop lookups, thus reducing the time complexity to O(1) for repeated lookups. This optimization increases the efficiency of styled prop detection without altering functionality.