### PR TITLE
feat: update next peer dependencies to resolve fouc issue

### DIFF
--- a/example/next-app-router/package.json
+++ b/example/next-app-router/package.json
@@ -16,7 +16,7 @@
     "@types/react": "^18.0.32",
     "@types/react-dom": "18.2.1",
     "eslint-config-next": "13.3.4",
-    "next": "^13.3.4",
+    "next": "^13.4.7",
     "react": "^18.2.0",
     "react-dom": "18.2.0"
   }

--- a/example/next-app-router/src/app/dynamic2.tsx
+++ b/example/next-app-router/src/app/dynamic2.tsx
@@ -1,0 +1,5 @@
+import { Box } from "@kuma-ui/core";
+
+export function Dynamic2() {
+  return <Box bg={(() => "yellow")()}>dynamic</Box>;
+}

--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { k, Box } from "@kuma-ui/core";
 import { Dynamic } from "./dynamic";
+import { Dynamic2 } from "./dynamic2";
 
 export default function Home() {
   return (
@@ -18,7 +19,7 @@ export default function Home() {
       </k.header>
       <Dynamic key={1} />
       <Dynamic key={2} />
-      <Box bg={(() => "yellow")()}>dynamic</Box>
+      <Dynamic2 />
       <Box color={(() => "colors.blue")()}>dynamic</Box>
       <Box p={[8, 16]} color="colors.green">
         static

--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -18,8 +18,10 @@ export default function Home() {
       </k.header>
       <Dynamic key={1} />
       <Dynamic key={2} />
+      <Box bg={(() => "yellow")()}>dynamic</Box>
+      <Box color={(() => "colors.blue")()}>dynamic</Box>
       <Box p={[8, 16]} color="colors.green">
-        test
+        static
       </Box>
     </div>
   );

--- a/example/next-app-router/src/app/registry.tsx
+++ b/example/next-app-router/src/app/registry.tsx
@@ -5,13 +5,13 @@ import { useServerInsertedHTML } from "next/navigation";
 import { StyleRegistry, createStyleRegistry } from "@kuma-ui/core";
 
 export function KumaRegistry({ children }: { children: React.ReactNode }) {
-  const [jsxStyleRegistry] = useState(() => createStyleRegistry());
+  const [registry] = useState(() => createStyleRegistry());
 
   useServerInsertedHTML(() => {
-    const styles = jsxStyleRegistry.styles();
-    jsxStyleRegistry.flush();
+    const styles = registry.styles();
+    registry.flush();
     return <>{styles}</>;
   });
 
-  return <StyleRegistry registry={jsxStyleRegistry}>{children}</StyleRegistry>;
+  return <StyleRegistry registry={registry}>{children}</StyleRegistry>;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,16 @@
   },
   "peerDependencies": {
     "@types/react": "^18.0.32",
-    "react": ">=18.2.0"
+    "react": ">=18.2.0",
+    "next": ">=13.4.5"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -45,7 +45,7 @@
     "webpack": "^5.78.0"
   },
   "peerDependencies": {
-    "next": ">=13",
+    "next": ">=13.4.5",
     "webpack": "^5"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
         specifier: 13.3.4
         version: 13.3.4(eslint@8.0.1)(typescript@5.0.4)
       next:
-        specifier: ^13.3.4
-        version: 13.3.4(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^13.4.7
+        version: 13.4.7(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2584,6 +2584,10 @@ packages:
     resolution: {integrity: sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg==}
     dev: false
 
+  /@next/env@13.4.7:
+    resolution: {integrity: sha512-ZlbiFulnwiFsW9UV1ku1OvX/oyIPLtMk9p/nnvDSwI0s7vSoZdRtxXNsaO+ZXrLv/pMbXVGq4lL8TbY9iuGmVw==}
+    dev: false
+
   /@next/eslint-plugin-next@13.3.4:
     resolution: {integrity: sha512-mvS+HafOPy31oJbAi920WJXMdjbyb4v5FAMr9PeGZfRIdEcsLkA3mU/ZvmwzovJgP3nAWw2e2yM8iIFW8VpvIA==}
     dependencies:
@@ -2600,6 +2604,15 @@ packages:
 
   /@next/swc-darwin-arm64@13.4.4:
     resolution: {integrity: sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-arm64@13.4.7:
+    resolution: {integrity: sha512-VZTxPv1b59KGiv/pZHTO5Gbsdeoxcj2rU2cqJu03btMhHpn3vwzEK0gUSVC/XW96aeGO67X+cMahhwHzef24/w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2624,6 +2637,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-darwin-x64@13.4.7:
+    resolution: {integrity: sha512-gO2bw+2Ymmga+QYujjvDz9955xvYGrWofmxTq7m70b9pDPvl7aDFABJOZ2a8SRCuSNB5mXU8eTOmVVwyp/nAew==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-arm64-gnu@13.3.4:
     resolution: {integrity: sha512-UqcKkYTKslf5YAJNtZ5XV1D5MQJIkVtDHL8OehDZERHzqOe7jvy41HFto33IDPPU8gJiP5eJb3V9U26uifqHjw==}
     engines: {node: '>= 10'}
@@ -2634,6 +2656,15 @@ packages:
 
   /@next/swc-linux-arm64-gnu@13.4.4:
     resolution: {integrity: sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-gnu@13.4.7:
+    resolution: {integrity: sha512-6cqp3vf1eHxjIDhEOc7Mh/s8z1cwc/l5B6ZNkOofmZVyu1zsbEM5Hmx64s12Rd9AYgGoiCz4OJ4M/oRnkE16/Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2658,6 +2689,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-linux-arm64-musl@13.4.7:
+    resolution: {integrity: sha512-T1kD2FWOEy5WPidOn1si0rYmWORNch4a/NR52Ghyp4q7KyxOCuiOfZzyhVC5tsLIBDH3+cNdB5DkD9afpNDaOw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-x64-gnu@13.3.4:
     resolution: {integrity: sha512-xU+ugaupGA4SL5aK1ZYEqVHrW3TPOhxVcpaJLfpANm2443J4GfxCmOacu9XcSgy5c51Mq7C9uZ1LODKHfZosRQ==}
     engines: {node: '>= 10'}
@@ -2668,6 +2708,15 @@ packages:
 
   /@next/swc-linux-x64-gnu@13.4.4:
     resolution: {integrity: sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-gnu@13.4.7:
+    resolution: {integrity: sha512-zaEC+iEiAHNdhl6fuwl0H0shnTzQoAoJiDYBUze8QTntE/GNPfTYpYboxF5LRYIjBwETUatvE0T64W6SKDipvg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2692,6 +2741,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-linux-x64-musl@13.4.7:
+    resolution: {integrity: sha512-X6r12F8d8SKAtYJqLZBBMIwEqcTRvUdVm+xIq+l6pJqlgT2tNsLLf2i5Cl88xSsIytBICGsCNNHd+siD2fbWBA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-arm64-msvc@13.3.4:
     resolution: {integrity: sha512-7dL+CAUAjmgnVbjXPIpdj7/AQKFqEUL3bKtaOIE1JzJ5UMHHAXCPwzQtibrsvQpf9MwcAmiv8aburD3xH1xf8w==}
     engines: {node: '>= 10'}
@@ -2702,6 +2760,15 @@ packages:
 
   /@next/swc-win32-arm64-msvc@13.4.4:
     resolution: {integrity: sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-arm64-msvc@13.4.7:
+    resolution: {integrity: sha512-NPnmnV+vEIxnu6SUvjnuaWRglZzw4ox5n/MQTxeUhb5iwVWFedolPFebMNwgrWu4AELwvTdGtWjqof53AiWHcw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2726,6 +2793,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-win32-ia32-msvc@13.4.7:
+    resolution: {integrity: sha512-6Hxijm6/a8XqLQpOOf/XuwWRhcuc/g4rBB2oxjgCMuV9Xlr2bLs5+lXyh8w9YbAUMYR3iC9mgOlXbHa79elmXw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-x64-msvc@13.3.4:
     resolution: {integrity: sha512-usdvZT7JHrTuXC+4OKN5mCzUkviFkCyJJTkEz8jhBpucg+T7s83e7owm3oNFzmj5iKfvxU2St6VkcnSgpFvEYA==}
     engines: {node: '>= 10'}
@@ -2736,6 +2812,15 @@ packages:
 
   /@next/swc-win32-x64-msvc@13.4.4:
     resolution: {integrity: sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-x64-msvc@13.4.7:
+    resolution: {integrity: sha512-sW9Yt36Db1nXJL+mTr2Wo0y+VkPWeYhygvcHj1FF0srVtV+VoDjxleKtny21QHaG05zdeZnw2fCtf2+dEqgwqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -7964,6 +8049,49 @@ packages:
       '@next/swc-win32-arm64-msvc': 13.4.4
       '@next/swc-win32-ia32-msvc': 13.4.4
       '@next/swc-win32-x64-msvc': 13.4.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
+
+  /next@13.4.7(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==}
+    engines: {node: '>=16.8.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      fibers: '>= 3.1.0'
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      fibers:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 13.4.7
+      '@swc/helpers': 0.5.1
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001488
+      postcss: 8.4.14
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.21.4)(react@18.2.0)
+      watchpack: 2.4.0
+      zod: 3.21.4
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 13.4.7
+      '@next/swc-darwin-x64': 13.4.7
+      '@next/swc-linux-arm64-gnu': 13.4.7
+      '@next/swc-linux-arm64-musl': 13.4.7
+      '@next/swc-linux-x64-gnu': 13.4.7
+      '@next/swc-linux-x64-musl': 13.4.7
+      '@next/swc-win32-arm64-msvc': 13.4.7
+      '@next/swc-win32-ia32-msvc': 13.4.7
+      '@next/swc-win32-x64-msvc': 13.4.7
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       '@kuma-ui/system':
         specifier: workspace:*
         version: link:../system
+      next:
+        specifier: '>=13.4.5'
+        version: 13.4.7(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: '>=18.2.0'
         version: 18.2.0


### PR DESCRIPTION
## Overview

If you're using a version of Next.js lower than v13.4.5 in the Next App Router environment and using Dynamic Props, a fouc (flash of unstyled content) may occur under certain conditions.

To address this issue, we will update the peer dependencies to encourage users to use Next.js v13.4.5 or higher.


https://github.com/poteboy/kuma-ui/assets/12913947/e081b65f-0a32-45cc-9d84-f8bb7fa2a47a

## What are the specific conditions?

It seems that fouc occurs when importing @kuma-ui/core from a Server Component, but no fouc occurs when importing it from a Client Component.

For example, if you check out the branch in this pull request and modify dynamic2.tsx in example/next-app-router as follows, the fouc issue will be resolved:

```diff
+ "use client";

import { Box } from "@kuma-ui/core";

export function Dynamic2() {
  return <Box bg={(() => "yellow")()}>dynamic</Box>
}
```

Please pay attention to the component with a yellow background. Even after refreshing the browser, fouc will not occur.

https://github.com/poteboy/kuma-ui/assets/12913947/a13d82d5-872d-4954-a771-04588877b154

## Why fouc occurs with versions lower than Next.js v13.4.5

In versions lower than Next.js v13.4.5, the Server Component imports cjs, while the Client Component imports mjs. This causes the [Dual Package Hazard](https://nodejs.org/api/packages.html#dual-package-hazard) issue. Starting from Next.js v13.4.5, both Server Component and Client Component import mjs.

You can verify this with the following steps:

Edit `example/next-app-router/node_modules/@kuma-ui/core/dist/registry/Registry.js`:

```diff
function createStyleRegistry() {
+  console.log("cjs: createStyleRegistry")
  return new import_StyleSheetRegistry.StyleSheetRegistry();
}
// ...
function useStyleRegistry() {
+  console.log("cjs: useStyleRegistry")
  return import_react.default.useContext(StyleSheetContext);
}
```

Edit `example/next-app-router/node_modules/@kuma-ui/core/dist/registry/Registry.mjs`:

```diff
function createStyleRegistry() {
+  console.log("mjs: createStyleRegistry")
  return new StyleSheetRegistry();
}
// ...
function useStyleRegistry() {
+  console.log("mjs: useStyleRegistry")
  return React.useContext(StyleSheetContext);
}
```

Install Next.js v13.4.4, start the server, and access it:

```
cd example/next-app-router
pnpm i next@13.4.4
npm run dev
```

You should see in the logs that cjs is imported and executed from the Server Component, while mjs is imported and executed from the Client Component.

![スクリーンショット 2023-07-04 10 50 57](https://github.com/poteboy/kuma-ui/assets/12913947/b873cb7d-4f0a-471c-adde-76eada6bb087)

Next, install Next.js v13.4.5, start the server, and access it:

```
cd example/next-app-router
pnpm i next@13.4.5
npm run dev
```

You should see in the logs that mjs is imported and executed from both the Server Component and the Client Component.

![スクリーンショット 2023-07-04 10 53 47](https://github.com/poteboy/kuma-ui/assets/12913947/37017f92-e29c-4e98-8ab3-0d3d4d6917f4)

