### PR TITLE
fix(core): fix speedy mode issue

### DIFF
--- a/example/next-app-router/src/app/dynamic.tsx
+++ b/example/next-app-router/src/app/dynamic.tsx
@@ -8,7 +8,7 @@ export function Dynamic() {
 
   return (
     <Box p={6} bg={checked ? "colors.blue" : "colors.green"}>
-      <Box mb={(() => [6, 12])()}>dynamic</Box>
+      <Box mb={[checked ? 6 : 0, 12]}>dynamic</Box>
       <Button onClick={() => toggle()}>Change Color</Button>
     </Box>
   );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,8 @@
   "dependencies": {
     "@kuma-ui/sheet": "workspace:*",
     "@kuma-ui/system": "workspace:*",
+    "@types/stylis": "^4.2.0",
+    "stylis": "^4.2.0",
     "ts-pattern": "^5.0.1"
   },
   "devDependencies": {
@@ -59,8 +61,8 @@
   },
   "peerDependencies": {
     "@types/react": "^18.0.32",
-    "react": ">=18.2.0",
-    "next": ">=13.4.5"
+    "next": ">=13.4.5",
+    "react": ">=18.2.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/core/src/registry/StyleSheetRegistry.ts
+++ b/packages/core/src/registry/StyleSheetRegistry.ts
@@ -1,4 +1,5 @@
 import React from "react";
+import { compile, serialize, stringify } from "stylis";
 import { StyleSheet } from "./sheet/StyleSheet";
 import { isBrowser } from "../utils/isBrowser";
 import { isProduction } from "../utils/isProduction";
@@ -7,70 +8,82 @@ const STYLE_ID_PREFIX = "__";
 
 export class StyleSheetRegistry {
   private sheet: StyleSheet;
-  private serverSideRenderedStyles: Record<string, HTMLStyleElement> | null =
-    null;
-  private indices: Record<string, number | undefined> = {};
-  private instancesCounts: Record<string, number | undefined> = {};
+  private serverSideRenderedStyleMap: {
+    [id: string]: HTMLStyleElement;
+  } | null = null;
+  private indexesMap: { [id: string]: number[] | undefined } = {};
+  private instancesCountMap: { [id: string]: number | undefined } = {};
 
   constructor() {
     this.sheet = new StyleSheet("kuma-ui", isProduction);
     this.sheet.inject();
   }
 
-  public add(id: string, rule: string): void {
-    if (isBrowser && this.serverSideRenderedStyles === null) {
-      this.serverSideRenderedStyles = this.getServerSideRenderedStyles();
-      Object.keys(this.serverSideRenderedStyles).forEach((id) => {
-        this.instancesCounts[id] = 0;
-        this.indices[id] = -1;
+  public add(id: string, css: string): void {
+    if (isBrowser && this.serverSideRenderedStyleMap === null) {
+      this.serverSideRenderedStyleMap = this.getServerSideRenderedStyleMap();
+      Object.keys(this.serverSideRenderedStyleMap).forEach((id) => {
+        this.instancesCountMap[id] = 0;
       });
     }
 
-    this.instancesCounts[id] = 1 + (this.instancesCounts[id] ?? 0);
-    const serverSideRenderedStyle = this.serverSideRenderedStyles?.[id];
-    if (this.instancesCounts[id] === 1 && !serverSideRenderedStyle) {
-      this.indices[id] = this.sheet.insertRule(rule, this.indices[id]);
+    this.instancesCountMap[id] = 1 + (this.instancesCountMap[id] ?? 0);
+    const serverSideRenderedStyle = this.serverSideRenderedStyleMap?.[id];
+    if (this.instancesCountMap[id] === 1 && !serverSideRenderedStyle) {
+      compile(css).forEach((element) => {
+        const rule = serialize([element], stringify);
+        this.indexesMap[id] = (this.indexesMap[id] || []).concat(
+          this.sheet.insertRule(rule)
+        );
+      });
     }
   }
 
   public remove(id: string): void {
-    if (
-      this.indices[id] === undefined ||
-      this.instancesCounts[id] === undefined
-    ) {
-      throw new Error(`StyleSheetRegistry: id: \`${id}\` not found.`);
+    if (this.instancesCountMap[id] === undefined) {
+      throw new Error(
+        `StyleSheetRegistry: id: \`${id}\` not found in idInstancesCountMap.`
+      );
     }
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.instancesCounts[id]! -= 1;
+    this.instancesCountMap[id]! -= 1;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    if (this.instancesCounts[id]! !== 0) {
+    if (this.instancesCountMap[id]! !== 0) {
       return;
     }
 
-    const serverSideRenderedStyle = this.serverSideRenderedStyles?.[id];
+    const serverSideRenderedStyle = this.serverSideRenderedStyleMap?.[id];
     if (serverSideRenderedStyle) {
       serverSideRenderedStyle.remove();
-      delete this.serverSideRenderedStyles?.[id];
+      delete this.serverSideRenderedStyleMap?.[id];
     } else {
+      if (this.indexesMap[id] === undefined) {
+        throw new Error(
+          `StyleSheetRegistry: id: \`${id}\` not found in idIndexesMap.`
+        );
+      }
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.sheet.deleteRule(this.indices[id]!);
+      this.indexesMap[id]!.forEach((index) => this.sheet.deleteRule(index));
+      delete this.indexesMap[id];
     }
 
-    delete this.indices[id];
-    delete this.instancesCounts[id];
+    delete this.instancesCountMap[id];
   }
 
   public styles(options: { nonce?: string } = {}) {
-    return Object.keys(this.indices)
+    return Object.keys(this.indexesMap)
       .map((id) => {
-        const index = this.indices[id];
-        if (index === undefined) {
+        const indexes = this.indexesMap[id];
+        if (indexes === undefined) {
           return null;
         }
         const cssRules = this.sheet.cssRules();
-        const rule = cssRules[index];
-        if (rule === undefined) {
+        const css = indexes
+          .map((index) => cssRules[index]?.cssText)
+          .filter(Boolean)
+          .join(this.sheet.isSpeedy() ? "" : "\n");
+        if (css.length === 0) {
           return null;
         }
         return React.createElement("style", {
@@ -78,22 +91,22 @@ export class StyleSheetRegistry {
           key: `${STYLE_ID_PREFIX}${id}`,
           nonce: options.nonce ? options.nonce : undefined,
           dangerouslySetInnerHTML: {
-            __html: rule.cssText,
+            __html: css,
           },
         });
       })
-      .filter((props) => props !== null);
+      .filter(Boolean);
   }
 
   public flush(): void {
     this.sheet.flush();
     this.sheet.inject();
-    this.serverSideRenderedStyles = null;
-    this.indices = {};
-    this.instancesCounts = {};
+    this.serverSideRenderedStyleMap = null;
+    this.indexesMap = {};
+    this.instancesCountMap = {};
   }
 
-  private getServerSideRenderedStyles() {
+  private getServerSideRenderedStyleMap() {
     const elements: HTMLStyleElement[] = Array.from(
       document.querySelectorAll(`[id^="${STYLE_ID_PREFIX}"]`)
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,12 +292,18 @@ importers:
       '@kuma-ui/system':
         specifier: workspace:*
         version: link:../system
+      '@types/stylis':
+        specifier: ^4.2.0
+        version: 4.2.0
       next:
         specifier: '>=13.4.5'
         version: 13.4.7(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: '>=18.2.0'
         version: 18.2.0
+      stylis:
+        specifier: ^4.2.0
+        version: 4.2.0
       ts-pattern:
         specifier: ^5.0.1
         version: 5.0.1
@@ -3304,7 +3310,6 @@ packages:
 
   /@types/stylis@4.2.0:
     resolution: {integrity: sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==}
-    dev: true
 
   /@types/testing-library__jest-dom@5.14.6:
     resolution: {integrity: sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==}


### PR DESCRIPTION
In order to improve the runtime performance in the production environment, speedy mode is enabled. When speedy mode is enabled, styles are updated using the CSSStyleSheet's insertRule API. However, we discovered an issue where the insertRule API throws an error when passed dynamic props like media queries to Kuma UI component.

https://github.com/poteboy/kuma-ui/assets/12913947/5f30a8e5-678e-4b8a-9932-1888c1f49168

This problem occurs because the insertRule API only accepts one rule at a time, as stated in the following documentation:　https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule

> Thrown if more than one rule is given in the rule parameter.

In practice, if multiple rules are passed, an error occurs, as shown in the example below:

```
document.styleSheets[0].insertRule(".kuma-2804477523{margin-bottom:6px;}@media (min-width:1000px){.kuma-2804477523{margin-bottom:12px;}}")
```

Therefore, it is necessary to pass each rule one by one, as demonstrated in the example below:

```
document.styleSheets[0].insertRule(".kuma-2804477523{margin-bottom:6px;}")
document.styleSheets[0].insertRule("@media (min-width:1000px){.kuma-2804477523{margin-bottom:12px;}}")
```

This pull request aims to resolve this issue. 