### PR TITLE
feat(core): enhance variant type

### DIFF
--- a/example/next-app-router/src/app/page.tsx
+++ b/example/next-app-router/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
       <Dynamic key={2} />
       <Dynamic2 />
       <Box color={(() => "colors.blue")()}>dynamic</Box>
-      <Box variant={(() => "action")()}>dynamic</Box>
+      <Box variant={(() => "action" as const)()}>dynamic</Box>
       <Box p={[8, 16]} color="colors.green">
         static
       </Box>

--- a/packages/core/src/components/Box/react/types.ts
+++ b/packages/core/src/components/Box/react/types.ts
@@ -1,5 +1,5 @@
 import { As, ComponentWithAs, ComponentProps } from "../../types";
 
-export type BoxProps = ComponentProps;
+export type BoxProps = ComponentProps<"Box">;
 
 export type BoxComponent<T extends As = "div"> = ComponentWithAs<T, BoxProps>;

--- a/packages/core/src/components/Box/react/utils.ts
+++ b/packages/core/src/components/Box/react/utils.ts
@@ -44,13 +44,13 @@ const styleCache: {
  * Incurs O(n log n) cost due to sorting, but it's acceptable given the
  * expensive nature of StyleGenerator's internals.
  */
-function generateKey (props: Record<string, any>) {
+function generateKey(props: Record<string, any>) {
   return Object.entries(props)
     .filter(([, value]) => value !== undefined)
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(([key, value]) => `${key}:${value}`)
     .join("|");
-};
+}
 
 export function getCachedStyle(dynamicProps: Record<string, any>) {
   const key = generateKey(dynamicProps);

--- a/packages/core/src/components/Button/react.tsx
+++ b/packages/core/src/components/Button/react.tsx
@@ -10,7 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 
-type ButtonProps = ComponentProps;
+type ButtonProps = ComponentProps<"Button">;
 
 type ButtonComponent<T extends As = "button"> = ComponentWithAs<T, ButtonProps>;
 

--- a/packages/core/src/components/Flex/react.tsx
+++ b/packages/core/src/components/Flex/react.tsx
@@ -10,7 +10,7 @@ import {
 } from "../types";
 import { Box } from "../Box";
 
-type FlexProps = ComponentProps;
+type FlexProps = ComponentProps<"Flex">;
 
 type FlexComponent<T extends As = "div"> = ComponentWithAs<T, FlexProps>;
 

--- a/packages/core/src/components/Heading/react.tsx
+++ b/packages/core/src/components/Heading/react.tsx
@@ -10,7 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 
-type HeadingProps = ComponentProps;
+type HeadingProps = ComponentProps<"Heading">;
 
 type HeadingComponent<
   T extends "h1" | "h2" | "h3" | "h4" | "h5" | "h6" = "h1"

--- a/packages/core/src/components/Spacer/react.tsx
+++ b/packages/core/src/components/Spacer/react.tsx
@@ -11,7 +11,7 @@ import { Box } from "../Box";
 import { SpacerSpecificProps, spacerHandler } from "./handler";
 import { theme } from "@kuma-ui/sheet";
 
-type SpacerProps = ComponentProps & SpacerSpecificProps;
+type SpacerProps = ComponentProps<"Spacer"> & SpacerSpecificProps;
 
 type SpacerComponent<T extends As = "div"> = ComponentWithAs<T, SpacerProps>;
 

--- a/packages/core/src/components/Text/react.tsx
+++ b/packages/core/src/components/Text/react.tsx
@@ -10,7 +10,7 @@ import {
 import { Box } from "../Box";
 import { theme } from "@kuma-ui/sheet";
 
-type TextProps = ComponentProps;
+type TextProps = ComponentProps<"Text">;
 
 type TextComponent<T extends As = "p"> = ComponentWithAs<T, TextProps>;
 

--- a/packages/core/src/components/types.ts
+++ b/packages/core/src/components/types.ts
@@ -1,3 +1,5 @@
+import { ThemeInput } from "./../theme";
+import { componentList } from "./componentList";
 import { StyledProps, PseudoProps } from "@kuma-ui/system";
 import { ReactNode } from "react";
 import { ThemeSystem } from "../theme";
@@ -46,9 +48,22 @@ type OmitCommonProps<
   OmitAdditionalProps extends keyof any = never
 > = Omit<Target, "transition" | "as" | "color" | OmitAdditionalProps>;
 
-export type ComponentProps = StyledProps<ThemeSystem> &
-  Partial<PseudoProps<ThemeSystem>> & {
-    children?: ReactNode;
-  } & {
-    variant?: string;
-  };
+type Variants<
+  T,
+  ComponentType extends keyof typeof componentList
+> = T extends Required<Required<ThemeInput>["components"]>[ComponentType]
+  ? T["variants"]
+  : never;
+
+type Variant<ComponentType extends keyof typeof componentList> = Extract<
+  keyof Variants<ThemeSystem["components"][ComponentType], ComponentType>,
+  string
+>;
+
+export type ComponentProps<ComponentType extends keyof typeof componentList> =
+  StyledProps<ThemeSystem> &
+    Partial<PseudoProps<ThemeSystem>> & {
+      children?: ReactNode;
+    } & {
+      variant?: Variant<ComponentType>;
+    };

--- a/packages/core/src/components/types.ts
+++ b/packages/core/src/components/types.ts
@@ -3,6 +3,7 @@ import { componentList } from "./componentList";
 import { StyledProps, PseudoProps } from "@kuma-ui/system";
 import { ReactNode } from "react";
 import { ThemeSystem } from "../theme";
+import { If, IsUnknown } from "../utils/types";
 
 /* eslint-disable @typescript-eslint/ban-types */
 export type As<Props = any> = React.ElementType<Props>;
@@ -55,9 +56,13 @@ type Variants<
   ? T["variants"]
   : never;
 
-type Variant<ComponentType extends keyof typeof componentList> = Extract<
-  keyof Variants<ThemeSystem["components"][ComponentType], ComponentType>,
-  string
+type Variant<ComponentType extends keyof typeof componentList> = If<
+  IsUnknown<ThemeSystem["components"][ComponentType]>,
+  never,
+  Extract<
+    keyof Variants<ThemeSystem["components"][ComponentType], ComponentType>,
+    string
+  >
 >;
 
 export type ComponentProps<ComponentType extends keyof typeof componentList> =

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -7,7 +7,7 @@ import {
 import { If, IsAny, Stringify, _String } from "./utils/types";
 import { componentList } from "./components/componentList";
 
-type ThemeInput = {
+export type ThemeInput = {
   colors?: NestedObject<string>;
   breakpoints?: Record<string, string>;
   components?: {

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -12,4 +12,8 @@ export type Stringify<T> = T extends string ? T : _String;
 
 export type IsAny<T> = 0 extends 1 & T ? true : false;
 
+export type IsUnknown<T> = unknown extends T
+  ? If<IsAny<T>, false, true>
+  : false;
+
 export type If<Q extends boolean, T, F> = Q extends true ? T : F;


### PR DESCRIPTION
Here's an example of code completion when setting variants for `Box` and `Flex` in a theme:

<img width="428" alt="スクリーンショット 2023-07-08 0 16 51" src="https://github.com/poteboy/kuma-ui/assets/12913947/fdd28f1e-3ebf-4dbb-b1e9-26281341d0b9">

<img width="422" alt="スクリーンショット 2023-07-08 0 16 28" src="https://github.com/poteboy/kuma-ui/assets/12913947/8aa5b28d-75c1-430b-9af6-e6b9f1a4e113">

<img width="521" alt="スクリーンショット 2023-07-08 0 16 05" src="https://github.com/poteboy/kuma-ui/assets/12913947/2b3666c6-7c99-4c45-83d5-dad85522d4e7">
