### PR TITLE
fix(core): fix className prefix issue at runtime

### DIFF
--- a/packages/core/src/components/Box/react/utils.ts
+++ b/packages/core/src/components/Box/react/utils.ts
@@ -57,7 +57,7 @@ export function getCachedStyle(dynamicProps: Record<string, any>) {
   let generatedStyle = styleCache[key];
   // If the result isn't in the cache, generate it and save it to the cache
   if (!generatedStyle) {
-    generatedStyle = new StyleGenerator(dynamicProps).getStyle();
+    generatedStyle = new StyleGenerator(dynamicProps, true).getStyle();
     styleCache[key] = generatedStyle;
   }
   return generatedStyle;


### PR DESCRIPTION
I have identified a bug where the prefix of dynamic style class names was set to 🐻 instead of 🦄. Regrettably, I introduced this bug during the timing of https://github.com/poteboy/kuma-ui/pull/181 .

As is:

<img width="332" alt="スクリーンショット 2023-07-09 2 33 57" src="https://github.com/poteboy/kuma-ui/assets/12913947/2935b7f7-7b19-4dce-95bc-7bbd459c35a0">

To be:

<img width="332" alt="スクリーンショット 2023-07-09 2 32 46" src="https://github.com/poteboy/kuma-ui/assets/12913947/0fdecabf-1862-4c29-88c7-b987aaa51c47">
