### PR TITLE
ci(release): add updating .npmrc step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
       - name: build packages
         run: pnpm run build
 
+      - name: Update .npmrc
+        run: echo -e "\n//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -35,4 +40,3 @@ jobs:
           publish: pnpm publish -r --access public --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fix release workflow error: https://github.com/poteboy/kuma-ui/actions/runs/5518476506/jobs/10062476761

https://github.com/changesets/action#with-publishing

> However, if a .npmrc file is found, the GitHub Action does not recreate the file. This is useful if you need to configure the .npmrc file on your own.