### PR TITLE
fix(website): Fix hero description visibility by adding `mix-blend-mode: plus-lighter` when using dark mode

### DIFF
--- a/website/src/components/home/hero.tsx
+++ b/website/src/components/home/hero.tsx
@@ -32,6 +32,9 @@ export const Hero = () => {
           fontSize="1.125rem"
           className={css`
             line-height: 1.75rem;
+            @media (prefers-color-scheme: dark) {
+              mix-blend-mode: plus-lighter;
+            }
           `}
         >
           With Kuma UI's headless, zero-runtime UI components, build


### PR DESCRIPTION
## Ticket

On discord ([context](https://discord.com/channels/1119672933477011598/1128165291210326067/1128353327051194409))

## Changes

- Adding `mix-blend-mode: plus-lighter` to the description in the hero component when viewed in dark mode
  |Before|After|
  |:--|:--|
  | <img width="1493" alt="image" src="https://github.com/poteboy/kuma-ui/assets/8467289/11cbbf9c-df25-4df5-a00a-063ac2ce5cb9">  | <img width="1495" alt="image" src="https://github.com/poteboy/kuma-ui/assets/8467289/520b4294-76d2-445b-8571-8d4b0af13edb">  |