### PR TITLE
Revert "fix(website): Fix hero description visibility by adding `mix-blend-mode: plus-lighter` when using dark mode"

### DIFF
--- a/website/src/components/home/hero.tsx
+++ b/website/src/components/home/hero.tsx
@@ -32,9 +32,6 @@ export const Hero = () => {
           fontSize="1.125rem"
           className={css`
             line-height: 1.75rem;
-            @media (prefers-color-scheme: dark) {
-              mix-blend-mode: plus-lighter;
-            }
           `}
         >
           With Kuma UI's headless, zero-runtime UI components, build


### PR DESCRIPTION
Reverts poteboy/kuma-ui#206