### PR TITLE
fix: fix exports field for typescript

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -19,9 +19,9 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
+    "types": "./types/index.d.ts",
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./types/index.d.ts"
+    "require": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -19,9 +19,9 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "types": "./dist/index.d.ts"
+    "require": "./dist/index.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
I moved the `exports.types` field to the beginning because it needs to be placed at the beginning for error-free importing.

![スクリーンショット 2023-07-13 22 26 53](https://github.com/poteboy/kuma-ui/assets/12913947/e99d89be-5209-42d4-890a-d03112f4ea23)
