### PR TITLE
Preventing 'Cannot convert undefined or null to object' error when using responsive styles without defined breakpoints

### DIFF
--- a/.changeset/afraid-apes-fold.md
+++ b/.changeset/afraid-apes-fold.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/sheet": patch
+---
+
+Preventing 'Cannot convert undefined or null to object' error when using responsive styles without defined breakpoints

--- a/example/next/tsconfig.json
+++ b/example/next/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,12 +16,20 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@src/*": ["./src/*"]
+      "@src/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/example/vite/kuma.config.ts
+++ b/example/vite/kuma.config.ts
@@ -8,10 +8,6 @@ const theme = createTheme({
     },
     green: "green",
   },
-  breakpoints: {
-    sm: "100px",
-    xl: "1000px",
-  },
   components: {
     Box: {
       baseStyle: {

--- a/example/vite/src/App.tsx
+++ b/example/vite/src/App.tsx
@@ -4,7 +4,7 @@ import { Dynamic } from "./Dynamic";
 function App() {
   const red = "red";
   return (
-    <HStack>
+    <HStack flexDir={["row", "column"]}>
       <Dynamic key={1} />
       <Dynamic key={2} />
     </HStack>

--- a/packages/sheet/src/theme.ts
+++ b/packages/sheet/src/theme.ts
@@ -49,7 +49,7 @@ export class Theme {
   private static instance: Theme;
   private _runtimeUserTheme: RuntimeUserTheme =
     globalThis.__KUMA_RUNTIME_USER_THEME__ ?? {
-      breakpoints: {},
+      breakpoints: defaultBreakpoints,
       components: {},
       tokens: {},
     };
@@ -69,10 +69,22 @@ export class Theme {
   }
 
   setUserTheme(userTheme: UserTheme) {
+    if (
+      !userTheme?.breakpoints ||
+      Object.keys(userTheme?.breakpoints).length === 0
+    ) {
+      userTheme.breakpoints = defaultBreakpoints;
+    }
     this._userTheme = userTheme;
   }
 
   setRuntimeUserTheme(runtimeUserTheme: RuntimeUserTheme) {
+    if (
+      !runtimeUserTheme?.breakpoints ||
+      Object.keys(runtimeUserTheme?.breakpoints).length === 0
+    ) {
+      runtimeUserTheme.breakpoints = defaultBreakpoints;
+    }
     this._runtimeUserTheme = runtimeUserTheme;
   }
 


### PR DESCRIPTION
this fixes #215.

Users have been experiencing a 'Cannot convert undefined or null to object' error when defining `kuma.config.ts` without setting breakpoints and then using responsive styles in Style Props (e.g., `flexDir={['column', 'row']}`).

This problem arises when there is a user-defined theme. The module bundler would override the theme as follows:
```ts
setUserTheme(userTheme: UserTheme) {
    this._userTheme = userTheme;
  }
```

In cases where breakpoints are not defined (i.e., are empty), this overrides the pre-existing defaultBreakpoints.

The oversight occurred because the bundler's plugin was type-asserting and embedding the theme in the following way, which will also need fixing eventually:

```ts
const config = eval(result.outputFiles[0].text, configPath) as {
        default: unknown;
      };

      if (config.default) {
        theme.setUserTheme(config.default as any);
      }
```