### PR TITLE
refactor: remove unnecessary processes

### DIFF
--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -32,7 +32,6 @@ const compile = (
       }
       const jsxTagName = openingElement.getTagNameNode().getText();
       // Check if the current JSX element is a Kuma component
-      if (!Object.values(bindings).includes(jsxTagName)) return;
       const originalComponentName = Object.keys(bindings).find(
         (key) =>
           bindings[key] === jsxTagName &&


### PR DESCRIPTION
Deleted processing considered unnecessary in compiler/src/compile.ts.
I think the deleted processing is already compensated for by the processing in the find method.

Sorry for the trivial fix, but please check it out!