### PR TITLE
fix/docs: Fix `Text` and `Heading` style in docs/darkmode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,10 @@ Our project uses `pnpm` and `turborepo`. Here's how you can set it up:
 
 1. Clone the repository.
 2. In the root directory, run `pnpm install` to install dependencies.
-3. Make your changes. If you modify the source code, make sure to build the project to see your changes in action.
-4. If you make any modifications, please test your changes. We prefer new features to come with tests.
-5. If you update the README, please run `node scripts/sync-files.js` from the root directory to sync changes.
+3. To use everything correctly, run `pnpm build` to compile the necessary packages.
+4. Make your changes. If you modify the source code, make sure to build the project to see your changes in action.
+5. If you make any modifications, please test your changes. We prefer new features to come with tests.
+6. If you update the README, please run `node scripts/sync-files.js` from the root directory to sync changes.
 
 ## Package Structure
 

--- a/website/src/components/example/Heading.tsx
+++ b/website/src/components/example/Heading.tsx
@@ -1,8 +1,14 @@
 import { Heading } from "@kuma-ui/core";
+import { useTheme } from "nextra-theme-docs";
 
 export const HeadingExample = () => {
+  const { theme } = useTheme();
   return (
-    <Heading as="h2" color="black" fontSize="24px">
+    <Heading
+      as="h2"
+      color={theme === "dark" ? "white" : "black"}
+      fontSize="24px"
+    >
       Hello world
     </Heading>
   );

--- a/website/src/components/example/Text.tsx
+++ b/website/src/components/example/Text.tsx
@@ -1,8 +1,10 @@
 import { Text } from "@kuma-ui/core";
+import { useTheme } from "nextra-theme-docs";
 
 export const TextExample = () => {
+  const { theme } = useTheme();
   return (
-    <Text color="black" fontSize="16px">
+    <Text color={theme === "dark" ? "white" : "black"} fontSize="16px">
       Hello world
     </Text>
   );


### PR DESCRIPTION
Hi everyone!

This PR fixes the issues in the docs where the examples of the `Text` and `Heading` components are not visible in dark mode. To achieve this, I used the built-in `useTheme()` function that `nextra` provides.

I also added a bit to the `Contributing.md` file regarding the necessity to run `pnpm build`.

Closes #221 