### PR TITLE
ci(release): fix issue with git tags not being pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   release:
-    name: Node ${{ matrix.node_version }} testing
+    name: Node ${{ matrix.node_version }} releasing
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,7 +32,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm publish -r --access public --no-git-checks
+          publish: pnpm changeset tag && pnpm publish -r --access public --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The changesets action pushes the Git tag with the following line:

https://github.com/changesets/action/blob/2bb9bcbd6bf4996a55ce459a630a0aa699457f59/src/run.ts#L133

As you can see in the following log, the Git tag is not being created, so it won't be pushed:

https://github.com/poteboy/kuma-ui/actions/runs/5566908304/jobs/10168383439

![スクリーンショット 2023-07-18 17 36 33](https://github.com/poteboy/kuma-ui/assets/12913947/81c18a9e-ed04-4ef3-83ae-ae481b655066)

Due to this issue, it is likely that the release notes are also not being generated.
To address this, we will add a command to generate the Git tag before publishing.

ref:

- https://github.com/pnpm/pnpm/issues/3586
- https://github.com/changesets/changesets/issues/612