### PR TITLE
feat(compiler): static branching to handle conditional expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
+    "@vitest/coverage-c8": "^0.31.4",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",

--- a/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
+++ b/packages/babel-plugin/src/__test__/__snapshots__/k.test.ts.snap
@@ -41,6 +41,21 @@ function App() {
 "
 `;
 
+exports[`k api > Snapshot tests (runtime: automatic) > using conditionals should match snapshot 1`] = `
+"
+.🐻-4229161508 { font-size: 24px; } .🐻-220318275 { font-size: 16px; }
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App({
+  flag
+}) {
+  return <__Box as=\\"div\\" IS_KUMA_DEFAULT={true} className={[\\"🐻-4229161508\\",\\"🐻-220318275\\"][1*!(flag)]}></__Box>;
+}
+"
+`;
+
 exports[`k api > Snapshot tests (runtime: automatic) > using pseudo elements should match snapshot 1`] = `
 "
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
@@ -134,6 +149,21 @@ function App() {
 "
 `;
 
+exports[`k api > Snapshot tests (runtime: classic) > using conditionals should match snapshot 1`] = `
+"
+.🐻-4229161508 { font-size: 24px; } .🐻-220318275 { font-size: 16px; }
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App({
+  flag
+}) {
+  return <__Box as=\\"div\\" IS_KUMA_DEFAULT={true} className={[\\"🐻-4229161508\\",\\"🐻-220318275\\"][1*!(flag)]}></__Box>;
+}
+"
+`;
+
 exports[`k api > Snapshot tests (runtime: classic) > using pseudo elements should match snapshot 1`] = `
 "
 .🐻-2631981251 { padding: 2px; }.🐻-2631981251:after { color: blue; }
@@ -223,6 +253,21 @@ function App() {
   return <__Box as=\\"div\\" IS_KUMA_DEFAULT={true} className={\`🐻-2131929892 \${css({
           boxShadow: '0 1px 2px 0 rgba(0, 0, 0, 0.05)'
         })}\`} />;
+}
+"
+`;
+
+exports[`k api > Snapshot tests (runtime: undefined) > using conditionals should match snapshot 1`] = `
+"
+.🐻-4229161508 { font-size: 24px; } .🐻-220318275 { font-size: 16px; }
+
+import { Box as __Box } from \\"@kuma-ui/core\\";
+import React from \\"react\\";
+import { k } from '@kuma-ui/core';
+function App({
+  flag
+}) {
+  return <__Box as=\\"div\\" IS_KUMA_DEFAULT={true} className={[\\"🐻-4229161508\\",\\"🐻-220318275\\"][1*!(flag)]}></__Box>;
 }
 "
 `;

--- a/packages/babel-plugin/src/__test__/k.test.ts
+++ b/packages/babel-plugin/src/__test__/k.test.ts
@@ -18,6 +18,20 @@ describe("k api", () => {
         expect(getExpectSnapshot(result)).toMatchSnapshot();
       });
 
+      test("using conditionals should match snapshot", async () => {
+        // Arrange
+        const inputCode = `
+        import { k } from '@kuma-ui/core'
+        function App({flag}) {
+          return <k.div fontSize={flag ? 24 : 16}></k.div>
+        }
+      `;
+        // Act
+        const result = await babelTransform(inputCode);
+        // Assert
+        expect(getExpectSnapshot(result)).toMatchSnapshot();
+      });
+
       test("using responsive props should match snapshot", async () => {
         // Arrange
         const inputCode = `

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "tsup --config ../../tsup.config.ts",
     "typecheck": "tsc --noEmit --composite false",
+    "test": "vitest run",
     "lint": "eslint './src/**/*.{js,ts,jsx,tsx}'",
     "lint:fix": "eslint --fix './src/**/*.{js,ts,jsx,tsx}'"
   },

--- a/packages/compiler/src/collector/collect.ts
+++ b/packages/compiler/src/collector/collect.ts
@@ -1,7 +1,5 @@
 import {
-  Project,
   Node,
-  SyntaxKind,
   JsxOpeningElement,
   JsxSelfClosingElement,
   JsxAttribute,
@@ -10,12 +8,14 @@ import { match } from "ts-pattern";
 import { decode } from "./decode";
 import { handleJsxExpression } from "./expression";
 import { extractPseudoAttribute } from "./pseudo";
+import { UnevaluatedConditionalExpression, unevaluatedConditionalExpression } from "../static-branching";
 
 export const collectPropsFromJsx = (
   node: JsxOpeningElement | JsxSelfClosingElement
-) => {
+): Record<string, any> => {
   const jsxAttributes = node.getAttributes();
   const extracted: Record<string, any> = {};
+
   jsxAttributes.forEach((jsxAttribute) => {
     if (Node.isJsxAttribute(jsxAttribute)) {
       const propName = jsxAttribute.getNameNode().getFullText();
@@ -31,32 +31,47 @@ export const collectPropsFromJsx = (
       extracted[propName] = propValue;
     }
   });
+
   return extracted;
 };
 
-const extractAttribute = (jsxAttribute: JsxAttribute) => {
+
+type AttributeValue = string | number | boolean | (string | number | undefined)[]
+
+
+const extractAttribute = (jsxAttribute: JsxAttribute): AttributeValue | UnevaluatedConditionalExpression | undefined => {
   const initializer = jsxAttribute.getInitializer();
 
-  return (
-    match(initializer)
-      // fontSize='24px'
-      .when(Node.isStringLiteral, (initializer) => {
-        const value = initializer.getLiteralText();
-        return value;
-      })
-      // fontSize={...}
-      .when(Node.isJsxExpression, (initializer) => {
-        const expression = initializer.getExpression();
-        if (!expression) return;
+  return match(initializer)
+    // fontSize='24px'
+    .when(Node.isStringLiteral, (initializer) => {
+      const value = initializer.getLiteralText();
+      return value;
+    })
+    // fontSize={...}
+    .when(Node.isJsxExpression, (initializer) => {
+      const expression = initializer.getExpression();
+      if (!expression) return;
 
-        const decodedNode = decode(expression);
-        return handleJsxExpression(decodedNode);
-      })
-      // If no initializer is present (e.g., <Spacer horizontal />), treat the prop as true
-      .when(
-        () => initializer === undefined,
-        () => true
-      )
-      .otherwise(() => undefined)
-  );
+      // fontSize={... ? ... : ...}
+      const conditionalExpression = match(expression).when(Node.isConditionalExpression, (conditional) => {
+        const condition = conditional.getCondition();
+        const whenTrue = handleJsxExpression(decode(conditional.getWhenTrue()));
+        const whenFalse = handleJsxExpression(decode(conditional.getWhenFalse()));
+        if (whenTrue === undefined || whenFalse === undefined) {
+          return undefined
+        }
+        return unevaluatedConditionalExpression({ expression: condition.getText(), whenTrue, whenFalse });
+      }).otherwise(() => undefined)
+      if (conditionalExpression) return conditionalExpression;
+
+      const decodedNode = decode(expression);
+      return handleJsxExpression(decodedNode);
+    })
+    // If no initializer is present (e.g., <Spacer horizontal />), treat the prop as true
+    .when(
+      () => initializer === undefined,
+      () => true
+    )
+    .otherwise(() => undefined)
 };

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -45,7 +45,7 @@ const compile = (
         componentName,
         openingElement,
         extractedPropsMap
-      );
+      )
       if (result) css.push(result.css);
     }
   });

--- a/packages/compiler/src/static-branching.test.ts
+++ b/packages/compiler/src/static-branching.test.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "vitest";
+import {
+  evaluateStaticBranching,
+  unevaluatedConditionalExpression,
+} from "./static-branching";
+
+test("evaluateStaticBranching without unevaluated conditional expression", async () => {
+  const result = evaluateStaticBranching({
+    bg: "red",
+    color: "black",
+  });
+
+  expect(result.indexExpression).toEqual("0");
+  expect(result.propsMapList).toEqual([{ bg: "red", color: "black" }]);
+});
+
+test("evaluateStaticBranching with two flags", async () => {
+  const result = evaluateStaticBranching({
+    bg: "red",
+    fontFamily: unevaluatedConditionalExpression({
+      expression: "flag0",
+      whenTrue: "monospace",
+      whenFalse: "sans-serif",
+    }),
+    m: unevaluatedConditionalExpression({
+      expression: "flag1",
+      whenTrue: 1,
+      whenFalse: 2,
+    }),
+  });
+
+  let flag0, flag1;
+
+  {
+    flag0 = true;
+    flag1 = true;
+
+    expect(result.propsMapList[eval(result.indexExpression)]).toEqual({
+      bg: "red",
+      fontFamily: "monospace",
+      m: 1,
+    });
+  }
+
+  {
+    flag0 = true;
+    flag1 = false;
+
+    expect(result.propsMapList[eval(result.indexExpression)]).toEqual({
+      bg: "red",
+      fontFamily: "monospace",
+      m: 2,
+    });
+  }
+});
+
+test("evaluateStaticBranching with duplicated flags", async () => {
+  const result = evaluateStaticBranching({
+    bg: "red",
+    fontFamily: unevaluatedConditionalExpression({
+      expression: "flag",
+      whenTrue: "monospace",
+      whenFalse: "sans-serif",
+    }),
+    m: unevaluatedConditionalExpression({
+      expression: "flag",
+      whenTrue: 1,
+      whenFalse: 2,
+    }),
+  });
+
+  // `flag` only appears once in the index expression
+  expect(result.indexExpression).toEqual("1*!(flag)");
+  // The same conditions are deduped
+  expect(result.propsMapList.length).toEqual(2);
+
+  let flag;
+
+  {
+    flag = false;
+    expect(result.propsMapList[eval(result.indexExpression)]).toEqual({
+      bg: "red",
+      fontFamily: "sans-serif",
+      m: 2,
+    });
+  }
+
+  {
+    flag = true;
+    expect(result.propsMapList[eval(result.indexExpression)]).toEqual({
+      bg: "red",
+      fontFamily: "monospace",
+      m: 1,
+    });
+  }
+});
+
+
+test("evaluateStaticBranching should give up when there are too many conditionals", async () => {
+  const result = evaluateStaticBranching({
+    p: 123,
+    bg: unevaluatedConditionalExpression({
+      expression: "flag0",
+      whenTrue: "red",
+      whenFalse: "black",
+    }),
+    color: unevaluatedConditionalExpression({
+      expression: "flag1",
+      whenTrue: "white",
+      whenFalse: "green",
+    }),
+    fontFamily: unevaluatedConditionalExpression({
+      expression: "flag2",
+      whenTrue: "monospace",
+      whenFalse: "sans-serif",
+    }),
+    m: unevaluatedConditionalExpression({
+      expression: "flag3",
+      whenTrue: 1,
+      whenFalse: 2,
+    }),
+  });
+
+  expect(result.indexExpression).toEqual("0");
+  // all the props with conditionas are removed here since "it gave up"
+  expect(result.propsMapList).toEqual([
+    { p: 123 }
+  ]);
+});

--- a/packages/compiler/src/static-branching.ts
+++ b/packages/compiler/src/static-branching.ts
@@ -1,0 +1,121 @@
+type AttributeValue = string | number | boolean | (string | number | undefined)[]
+
+export interface UnevaluatedConditionalExpression {
+  type: 'UnevaluatedConditionalExpression',
+  expression: string,
+  whenTrue: AttributeValue
+  whenFalse: AttributeValue
+}
+
+
+export const unevaluatedConditionalExpression = (x: {
+  expression: string,
+  whenTrue: AttributeValue
+  whenFalse: AttributeValue
+}): UnevaluatedConditionalExpression => ({
+  type: 'UnevaluatedConditionalExpression',
+  ...x
+})
+
+
+const COMBINATION_COUNT_MAX = 8;
+
+/**
+ * Convert `propsMapWithUnevaluatedConditionals` into a list of propsMap (`propsMapList`), where each of them corresponds to one insantiation of an actual set of values for conditional expressions.
+ * It also returns `indexExpression`, which will be evaluated into an integer during runtime to index the corresponding position in `propsMapList`
+ *
+ * If it could generate too many possibilities, it falls back to completely dynamic behavior.
+ *
+ * Note that the returned `propsMapList` should always contain at least one element
+ */
+export const evaluateStaticBranching = (
+  propsMapWithUnevaluatedConditionals: Record<string, any>,
+): {
+  propsMapList: Record<string, any>[],
+  /**
+   * e.g. "1*!(props.flagA) + 2*!(props.flagB)"
+   */
+  indexExpression: string
+} => {
+
+  const unevaluatedConditionalExpressions: UnevaluatedConditionalExpression[] =
+    Object.values(propsMapWithUnevaluatedConditionals).filter(
+      (val) => val.type === "UnevaluatedConditionalExpression",
+    );
+
+  const normalizedExpressions: string[] = Array.from(
+    new Set(
+      unevaluatedConditionalExpressions.map((t) => t.expression),
+    ),
+  );
+
+  const evaluateConditionals = (
+    normalizedConditionalExpressionValues: Map<string, boolean>,
+  ) => {
+    let conditionalIndex = 0;
+    return Object.fromEntries(
+      Object.entries(propsMapWithUnevaluatedConditionals).map(([k, v]) => {
+        if (v.type === "UnevaluatedConditionalExpression") {
+          const condition =
+            unevaluatedConditionalExpressions[conditionalIndex++];
+          const expressionText = condition.expression;
+          if (!normalizedConditionalExpressionValues.has(expressionText)) {
+            throw new Error(
+              "normalizedConditionalExpressionValues does not include the expression: " +
+              expressionText,
+            );
+          }
+          return [
+            k,
+            normalizedConditionalExpressionValues.get(expressionText)
+              ? condition.whenFalse
+              : condition.whenTrue,
+          ];
+        }
+        return [k, v];
+      }),
+    );
+  };
+
+  const normalizedConditionalExpressionValues = new Map<string, boolean>();
+  const combinationCount = 2 ** normalizedExpressions.length;
+
+  const propsMapList = [];
+
+  // Avoid generating too many combinations. If we detect too many combinations could be generated, let's just disable the whole logic for static conditional analysis
+  if (combinationCount > COMBINATION_COUNT_MAX) {
+    return {
+      propsMapList: [
+        Object.fromEntries(
+          Object.entries(propsMapWithUnevaluatedConditionals).filter(
+            ([_k, v]) => v.type !== "UnevaluatedConditionalExpression",
+          ),
+        ),
+      ],
+      indexExpression: "0",
+    };
+  }
+
+  for (
+    let combinationIndex = 0;
+    combinationIndex < combinationCount;
+    ++combinationIndex
+  ) {
+    normalizedExpressions.forEach((expression, i) => {
+      normalizedConditionalExpressionValues.set(
+        expression,
+        !!((combinationIndex >> i) & 1),
+      );
+    });
+    propsMapList.push(
+      evaluateConditionals(normalizedConditionalExpressionValues),
+    );
+  }
+  return {
+    propsMapList,
+    indexExpression: normalizedExpressions
+      .map((condition, i) => `${2 ** i}*!(${condition})`)
+      .join(" + ") || '0',
+  };
+};
+

--- a/packages/compiler/vitest.config.ts
+++ b/packages/compiler/vitest.config.ts
@@ -1,0 +1,3 @@
+import { configShared } from "../../vitest.shared";
+
+export default configShared;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5.57.1
         version: 5.57.1(eslint@8.0.1)(typescript@5.0.4)
+      '@vitest/coverage-c8':
+        specifier: ^0.31.4
+        version: 0.31.4(vitest@0.31.4)
       eslint:
         specifier: ^8.0.1
         version: 8.0.1


### PR DESCRIPTION
**Note: this PR might not be what Kuma UI core devs want to have (See "Tradeoffs" section). In this case, feel free to just reject it! It was just fun to explore the code base for my learning purpose**

This PR implements a new way to make more patterns "static".
During the build time, the following:

```tsx
<Box
  fontSize={props.flagA ? 32 : 16}
  color="#123456"
  bg={props.flagA ? "red" : "green"}
  display={props.flagB ? "flex" : "block"}
/>
```
becomes

```tsx
<Box
  className={[
    "🐻-3426465140",
    "🐻-3583227940",
    "🐻-676607144",
    "🐻-2454055305",
  ][1 * !(props.flagA) + 2 * !(props.flagB)]}
/>
```
with static CSS output. There is a limitation for the maximum number of combinations (hardcoded as `8` in this PR) but practically we should not have too many flags in styles anyway.

* Now `extractAttribute` can return UnevaluatedConditionalExpression, which holds the conditional expression, whenTrue, and whenFalse
* Then `extractProps` calls `evaluateStaticBranching` in a newly added `static-branching.ts` to statically branch the potential paths. For each possibility, it will generate CSS along with "index expression", which will be used to choose actual className in runtime.
* the logic to update className is extracted into dedicated function `updateClassNameAttr` to be used in the final stage after the static branching
* I also added vitest tests to compiler package since I wanted to add focused unit test for `static-branching.ts` but not sure whether this is the right way

Note that I did not modify extractPseudoAttribute for now. I think it's better to start small rather than modifying too many places until this gets proven to be actually useful

## Tradeoffs

This strategy has several benefits and drawbacks.
I would like Kuma UI core devs to think about these trade offs before deciding whether we should merge this PR or not.

### Benefits
* I think having **a few** conditionals in styling is really common pattern in any styling solutions, one example can be like "modal open / closed based on useState". Some of these patterns can be solved in CSS level such as special selectors but in many cases it's easier to just rely on some JS variable to switch styling.
  * Notably, this pattern has been really easy with both traditional CSS convention (e.g. [SUIT state](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md#componentnameis-stateofcomponent)) and Tailwind (e.g. just `flag ? 'bg-red' : 'bg-blue'`) without adding performance cost. People can still say "CSS-in-JS" is slow just due to this pattern since it is common pattern.
* Kuma UI might decide to implement other strategies to make more patterns static, however, this "static branching" strategy is orthogonal to other strategies. For example, even if Kuma UI adopts Linaria's way, this "static branching" strategy is still beneficial since there will be always "unresolvable" variables during build time.

### Drawbacks
* Increased maintenance cost (to mitigate this, I tried to isolate the logic from the existing code. The main logic lives in `static-branching.ts` with unit tests)
* Increased compile time (haven't measured yet but I suspect anyway there is several other places to optimize)
* For end users, it will be harder to understand "which pattern can be statically extracted or not" (This might not be an big issue since we have 🐻 emoji during development)
* Increased CSS size: it will generate larger CSS. This can be mitigated by CSS optimizers in production such as [lightning CSS](https://lightningcss.dev/). We might be able to rely on features such as [CSSO's "scopes" option](https://github.com/css/csso#scopes) as well for maximum optimization. Note that I created [an example using CSSO here](https://stackblitz.com/edit/stackblitz-starters-zfeey5?file=index.js). To mitigate this issue from another angle, I think we can consider atomic CSS output like Linaria does. However this also has its own trade off: HTML output will be larger for excessively repeated elements.

## Alternatives considered
As an alternative, we could generate multiple static classNames for each conditional, however in this PR I did not choose this path simply because the code will be more complicated. I believe that practically generated styles will not be so large especially with CSS optimizers and the runtime performance matters more. This way can be easier if the overall design is based on "atomic styles" like Linaria does in https://github.com/callstack/linaria/pull/867

## Future potential improvements

Here is the list of things I did not implement in this PR to avoid too much change at this point:

- `static-branching.ts` can be further improved like recognizing "actually the same flag" such as `!flag` and `flag`. This kind of improvement should not add much maintenance cost since it's completely encapsulated in `static-branching.ts`
- We can also support conditional expressions inside arbitrary expressions such as `{margin: flag ? 1 : 2}`. This will be especially useful for pseudo props such as `_hover`

We might want to do further refactor if we go with this path. For example, probably it's better to reconsider the usage of ts-morph in favor of babel if there is no actual plan to utilize type information. Babel has very useful utilities such as `nodePath.evaluate` ([StackBlitz example](https://stackblitz.com/edit/stackblitz-starters-ssaprd?file=index.js))

## Manual testing with Next.js

I tested this change with Next.js using the following code:
```tsx
const Page = () => {
  return (
    <Box fontFamily="sans-serif" color="#555555" m={32} border="1px solid #cccccc">
      {Array.from({ length: 10 }, (_, i) => (
        <Box key={i} bg={i % 2 === 0 ? "#cccccc" : "#ffffff"} p={8}>
          Item {i}
        </Box>
      ))}
    </Box>
  );
};
```
Before this PR, this falled back to "dynamic mode" and without [`KumaRegistry`](https://www.kuma-ui.com/docs/install#server-side-rendering), it was causing FOUC.

<img width="500" alt="before" src="https://github.com/poteboy/kuma-ui/assets/2931577/30ec358a-c1e6-460b-90cc-1d89349124ea">

After this PR, this generates two class names with styles statically and there is no FOUC since now it's "static" (almost exactly the same performance as Tailwind / manual CSS except for the overhead of `Box` itself, which is different thing we could optimize out in the future)

<img width="500" alt="after" src="https://github.com/poteboy/kuma-ui/assets/2931577/f7ea8fa0-b0ce-483d-8ed8-8d924ca2427b">

## Misc: How other libraries are doing?
~TODO: This might be kind of novel idea (similar idea originally coming from my closed source prototype several years ago) but not sure. I suspect some popular libs might have similar logic, let me know if anyone find such code since I am interested!~

- [Panda can handle conditionals statically](https://github.com/poteboy/kuma-ui/pull/229?notification_referrer_id=NT_kwDOACy7ebI3MDk2Nzk2NzA3OjI5MzE1Nzc#issuecomment-1639985897)

## Things to care if we decide to ship this PR
* Documentations / blogs are referring this pattern as "dynamic" but now it's not. Probably better to update them where possible. e.g. https://www.kuma-ui.com/docs/Concepts/Hybrid#why-the-hybrid-approach shows conditional expression pattern as "dynamic"
