### PR TITLE
ci(release): fix publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
         node_version: [16]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Setup node ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
 
@@ -32,7 +32,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset tag && pnpm publish -r --access public --no-git-checks
+          publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I received a report from @taishinaritomi that commands using && are not working correctly. It seems that they need to be converted to npm scripts or shell scripts.

After doing some research, I found that projects using pnpm are executing `changeset publish`:

- https://github.com/callstack/linaria
- https://github.com/vanilla-extract-css/vanilla-extract

As mentioned below, `changeset publish` includes Git tags:

https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#tag
> The tag command creates git tags for the current version of all packages. The tags created are equivalent to those created by [changeset publish](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#publish), but the tag command does not publish anything to npm.

Therefore, we will switch to using `changeset publish` for publishing.


