### PR TITLE
feat(vite): use virtual modules

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -5,7 +5,6 @@ import { buildSync } from "esbuild";
 import _eval from "eval";
 import { theme, sheet } from "@kuma-ui/sheet";
 import { readdirSync } from "fs";
-import { StyleGenerator } from "@kuma-ui/system";
 
 export default function kumaUI(): Plugin {
   let mode: "build" | "serve";
@@ -40,6 +39,7 @@ export default function kumaUI(): Plugin {
   }
 
   const cssLookup: { [key: string]: string } = {};
+  const virtualModuleId = "virtual:kuma-ui";
 
   const userTheme = theme.getUserTheme();
 
@@ -65,26 +65,24 @@ export default function kumaUI(): Plugin {
       const cssRelativePath = path
         .relative(process.cwd(), cssFilename)
         .replace(/\\/g, path.posix.sep);
-      const cssId = `/${cssRelativePath}`;
       // const css = sheet.getCSS();
       const css =
         ((result.metadata as unknown as { css: string }).css as string) || "";
-      cssLookup[cssFilename] = css;
-      cssLookup[cssId] = css;
+      cssLookup[cssRelativePath] = css;
       sheet.reset();
-      if (mode === "serve") return injectCSS(css, cssId) + result.code;
-      return `import ${JSON.stringify(cssFilename)};\n` + result.code;
+      return (
+        `import "${virtualModuleId}/${cssRelativePath}";
+` + result.code
+      );
     },
-    load(url: string) {
-      const [id] = url.split("?");
+    load(url) {
+      if (!url.startsWith(`\0${virtualModuleId}`)) return undefined;
+      const id = url.slice(`\0${virtualModuleId}`.length + 1);
       return cssLookup[id];
     },
-    resolveId(importeeUrl: string) {
-      const [id, qsRaw] = importeeUrl.split("?");
-      if (id in cssLookup) {
-        if (qsRaw?.length) return importeeUrl;
-        return id;
-      }
+    resolveId(importeeUrl) {
+      if (!importeeUrl.startsWith(virtualModuleId)) return undefined;
+      return `\0${importeeUrl}`;
     },
     handleHotUpdate({ server, file }) {
       sheet.reset();
@@ -95,25 +93,3 @@ export default function kumaUI(): Plugin {
     },
   };
 }
-
-const injectCSS = (cssContent: string, fileId: string) => {
-  return `
-  (function() {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    const css = ${JSON.stringify(cssContent)};
-    const kumaStyleId = 'kuma-ui-styles-' + ${JSON.stringify(fileId)};
-    let style = document.getElementById(kumaStyleId);
-    const head = document.head || document.getElementsByTagName('head')[0];
-
-    if (!style) {
-      style = document.createElement('style');
-      style.type = 'text/css';
-      style.id = kumaStyleId;
-      head.appendChild(style);
-    }
-    style.textContent = css;
-  })();
-  `;
-};


### PR DESCRIPTION
I want to release the implementation of using [virtual modules](https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention) from https://github.com/poteboy/kuma-ui/pull/211 to import CSS.

dev server:

![スクリーンショット 2023-07-19 0 44 31](https://github.com/poteboy/kuma-ui/assets/12913947/5f7e78f2-93ca-465b-8c18-12be8eb95154)

production build:

![スクリーンショット 2023-07-19 0 45 16](https://github.com/poteboy/kuma-ui/assets/12913947/bc77d8d8-918b-4b56-b576-b2ef51875917)
