### PR TITLE
fix(babel-plugin): Race condition bug which can cause missing styles

### DIFF
--- a/.changeset/rude-baboons-perform.md
+++ b/.changeset/rude-baboons-perform.md
@@ -1,0 +1,5 @@
+---
+"@kuma-ui/babel-plugin": minor
+---
+
+fix(babel-plugin): Race condition bug which can cause missing styles

--- a/packages/babel-plugin/src/transform.ts
+++ b/packages/babel-plugin/src/transform.ts
@@ -4,7 +4,7 @@ import pluin from ".";
 import { sheet } from "@kuma-ui/sheet";
 
 export async function transform(code: string, id: string) {
-  const result = await transformSync(code, {
+  const result = transformSync(code, {
     filename: id,
     sourceMaps: true,
     plugins: [pluin],


### PR DESCRIPTION
There is a race condition in `transform()` in `@kuma-ui/babel-plugin` and in some cases, **styles will not be generated to CSS files**.
The probably of having accidentally missing CSS from prod build seems to be relatively high for reasonably big project.

(credit: this was reported in Discord, thanks the reporter (not sure about GitHub username)! I enjoyed debugging this)

1. `@kuma-ui/webpack-plugin` calls `transform()` from `@kuma-ui/babel-plugin` ([code](https://github.com/poteboy/kuma-ui/blob/76188d48ec19e96de6760dbb8d25c0b939d9ff6a/packages/webpack-plugin/src/loader.ts#L35-L35))
2. `transform()` in `@kuma-ui/babel-plugin` calls actual babel plugin via transformSync [here](https://github.com/poteboy/kuma-ui/blob/76188d48ec19e96de6760dbb8d25c0b939d9ff6a/packages/babel-plugin/src/transform.ts#L7-L7)
3. Inside the babel plugin, `sheet.addRule()` is called to add styles ([code](https://github.com/poteboy/kuma-ui/blob/76188d48ec19e96de6760dbb8d25c0b939d9ff6a/packages/babel-plugin/src/processCSS.ts#L66-L66))
4. Later in `transform()` in `@kuma-ui/babel-plugin`, [`sheet.reset()` is called](https://github.com/poteboy/kuma-ui/blob/908fc49f6a11ca55164028c030a9b863d1ff5f78/packages/babel-plugin/src/transform.ts#L21-L21)

The problem is that the sheet is singleton instance and "something" can happen between 3. and 4. because there is `await` [here](https://github.com/poteboy/kuma-ui/blob/76188d48ec19e96de6760dbb8d25c0b939d9ff6a/packages/babel-plugin/src/transform.ts#L7-L7). And sometimes, "something" can be `sheet.reset()` for an unrelated file. This can cause "style is not generated in CSS" situation.

## Solution

Just remove `await` and ensure nothing can interleave as long as the sheet is used for a specific file.
This race condition is not obvious from the code / file structure so if there is better way to structure code it would be nice though

