### PR TITLE
fix: correctly compile falsy property values

### DIFF
--- a/packages/compiler/src/collector/collect.ts
+++ b/packages/compiler/src/collector/collect.ts
@@ -27,7 +27,7 @@ export const collectPropsFromJsx = (
         propValue = extractAttribute(jsxAttribute);
       }
       // If the value is returned, it means that it can be statically analyzed, so we remove the corresponding prop from the Jsx tag and generate CSS.
-      if (!propValue) return;
+      if (!propValue && propValue !== 0) return;
       extracted[propName] = propValue;
     }
   });

--- a/packages/compiler/src/collector/collect.ts
+++ b/packages/compiler/src/collector/collect.ts
@@ -27,7 +27,7 @@ export const collectPropsFromJsx = (
         propValue = extractAttribute(jsxAttribute);
       }
       // If the value is returned, it means that it can be statically analyzed, so we remove the corresponding prop from the Jsx tag and generate CSS.
-      if (!propValue && propValue !== 0) return;
+      if (propValue == undefined) return;
       extracted[propName] = propValue;
     }
   });

--- a/packages/system/src/animation.test.ts
+++ b/packages/system/src/animation.test.ts
@@ -22,6 +22,7 @@ describe("animation utility function", () => {
       "animation-timing-function: ease-in;",
       "",
     ],
+    [{ animationIterationCount: 0 }, "animation-iteration-count: 0;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/animation.ts
+++ b/packages/system/src/animation.ts
@@ -38,7 +38,7 @@ export const animation = (props: AnimationProps): ResponsiveStyle => {
 
   for (const key in animationMappings) {
     const cssValue = props[key as AnimationKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = animationMappings[key as AnimationKeys];
       const responsiveStyles = applyResponsiveStyles(
         property,

--- a/packages/system/src/border.test.ts
+++ b/packages/system/src/border.test.ts
@@ -6,6 +6,7 @@ describe("border utility function", () => {
   const testCases: Array<[BorderProps, string, string]> = [
     [{ borderRadius: 1 }, "border-radius: 1px;", ""],
     [{ borderWidth: "20px" }, "border-width: 20px;", ""],
+    [{ borderWidth: 0 }, "border-width: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/border.ts
+++ b/packages/system/src/border.ts
@@ -26,7 +26,7 @@ export const border = (props: BorderProps): ResponsiveStyle => {
 
   for (const key in borderMappings) {
     const cssValue = props[key as BorderKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = borderMappings[key as BorderKeys];
       const converter = [
         borderMappings.borderWidth,

--- a/packages/system/src/color.test.ts
+++ b/packages/system/src/color.test.ts
@@ -11,6 +11,7 @@ describe("color utility function", () => {
     [{ accentColor: "red" }, "accent-color: red;", ""],
     [{ caretColor: "red" }, "caret-color: red;", ""],
     [{ opacity: 0.5 }, "opacity: 0.5;", ""],
+    [{ opacity: 0 }, "opacity: 0;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/color.ts
+++ b/packages/system/src/color.ts
@@ -48,7 +48,7 @@ export const color = (props: ColorProps): ResponsiveStyle => {
   const media: ResponsiveStyle["media"] = {};
   for (const key in colorMappings) {
     const cssValue = props[key as ColorKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = colorMappings[key as ColorKeys];
       const userTheme = theme.getUserTheme();
       let converter: (value: string | number) => string | number;

--- a/packages/system/src/column.test.ts
+++ b/packages/system/src/column.test.ts
@@ -18,6 +18,7 @@ describe("outline utility function", () => {
     [{ columnWidth: "auto" }, "column-width: auto;", ""],
     [{ columns: 2 }, "columns: 2;", ""],
     [{ columns: "auto 2" }, "columns: auto 2;", ""],
+    [{ columnWidth: 0 }, "column-width: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/column.ts
+++ b/packages/system/src/column.ts
@@ -40,7 +40,7 @@ export const column = (props: ColumnProps): ResponsiveStyle => {
 
   for (const key in columnMappings) {
     const cssValue = props[key as ColumnKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = columnMappings[key as ColumnKeys];
       const converter = [
         columnMappings.columnGap,

--- a/packages/system/src/effect.ts
+++ b/packages/system/src/effect.ts
@@ -34,7 +34,7 @@ export const effect = (props: EffectProps): ResponsiveStyle => {
 
   for (const key in effectMappings) {
     const cssValue = props[key as EffectKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = effectMappings[key as EffectKeys];
       const responsiveStyles = applyResponsiveStyles(property, cssValue);
       base += responsiveStyles.base;

--- a/packages/system/src/effect.ts
+++ b/packages/system/src/effect.ts
@@ -34,7 +34,7 @@ export const effect = (props: EffectProps): ResponsiveStyle => {
 
   for (const key in effectMappings) {
     const cssValue = props[key as EffectKeys];
-    if (cssValue != undefined) {
+    if (cssValue) {
       const property = effectMappings[key as EffectKeys];
       const responsiveStyles = applyResponsiveStyles(property, cssValue);
       base += responsiveStyles.base;

--- a/packages/system/src/flex.test.ts
+++ b/packages/system/src/flex.test.ts
@@ -21,6 +21,7 @@ describe("flex utility function", () => {
     [{ justifySelf: "center" }, "justify-self: center;", ""],
     [{ gap: 1 }, "gap: 1px;", ""],
     [{ gap: "10px 20px" }, "gap: 10px 20px;", ""],
+    [{ gap: 0 }, "gap: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/flex.ts
+++ b/packages/system/src/flex.ts
@@ -45,7 +45,7 @@ export const flex = (props: FlexProps): ResponsiveStyle => {
 
   for (const key in flexMappings) {
     const cssValue = props[key as FlexKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = flexMappings[key as FlexKeys];
       const converter = [flexMappings.flexBasis, flexMappings.gap].includes(
         property

--- a/packages/system/src/font.test.ts
+++ b/packages/system/src/font.test.ts
@@ -12,6 +12,7 @@ describe("font utility function", () => {
       "font-size: 24px;",
       "@media (min-width: 576px) { font-size: 32px; }",
     ],
+    [{ fontSize: 0 }, "font-size: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/font.ts
+++ b/packages/system/src/font.ts
@@ -59,7 +59,7 @@ export const font = (props: FontProps): ResponsiveStyle => {
 
   for (const key in fontMappings) {
     const cssValue = props[key as FontKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = fontMappings[key as FontKeys];
       const converter = [fontMappings.fontSize].includes(property)
         ? toCssUnit

--- a/packages/system/src/grid.test.ts
+++ b/packages/system/src/grid.test.ts
@@ -12,6 +12,7 @@ describe("grid utility function", () => {
       "grid-gap: 8px;",
       "@media (min-width: 576px) { grid-gap: 16px; }",
     ],
+    [ { gridColumnStart: 0 }, "grid-column-start: 0;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/grid.ts
+++ b/packages/system/src/grid.ts
@@ -37,7 +37,7 @@ export const grid = (props: GridProps): ResponsiveStyle => {
 
   for (const key in gridMappings) {
     const cssValue = props[key as GridKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = gridMappings[key as GridKeys];
       const converter = unitKeys.includes(key as UnitKeys)
         ? toCssUnit

--- a/packages/system/src/layout.ts
+++ b/packages/system/src/layout.ts
@@ -30,7 +30,7 @@ export const layout = (props: LayoutProps): ResponsiveStyle => {
   const media: ResponsiveStyle["media"] = {};
   for (const key in layoutMappings) {
     const cssValue = props[key as LayoutKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = layoutMappings[key as LayoutKeys];
       const converter = [
         layoutMappings.width,

--- a/packages/system/src/list.ts
+++ b/packages/system/src/list.ts
@@ -21,7 +21,7 @@ export const list = (props: ListProps): ResponsiveStyle => {
 
   for (const key in listMappings) {
     const cssValue = props[key as ListKeys];
-    if (cssValue != undefined) {
+    if (cssValue) {
       const property = listMappings[key as ListKeys];
       const responsiveStyles = applyResponsiveStyles(property, cssValue);
       base += responsiveStyles.base;

--- a/packages/system/src/list.ts
+++ b/packages/system/src/list.ts
@@ -21,7 +21,7 @@ export const list = (props: ListProps): ResponsiveStyle => {
 
   for (const key in listMappings) {
     const cssValue = props[key as ListKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = listMappings[key as ListKeys];
       const responsiveStyles = applyResponsiveStyles(property, cssValue);
       base += responsiveStyles.base;

--- a/packages/system/src/mask.test.ts
+++ b/packages/system/src/mask.test.ts
@@ -48,6 +48,7 @@ describe("mask utility function", () => {
     [{ maskSize: 10 }, "mask-size: 10px;", ""],
     [{ maskSize: "10% 20%" }, "mask-size: 10% 20%;", ""],
     [{ maskType: "luminance" }, "mask-type: luminance;", ""],
+    [{ maskBorderWidth: 0 }, "mask-border-width: 0;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/mask.ts
+++ b/packages/system/src/mask.ts
@@ -51,7 +51,7 @@ export const mask = (props: MaskProps): ResponsiveStyle => {
 
   for (const key in maskMappings) {
     const cssValue = props[key as MaskKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = maskMappings[key as MaskKeys];
       const converter = [maskMappings.maskSize].includes(property)
         ? toCssUnit

--- a/packages/system/src/outline.test.ts
+++ b/packages/system/src/outline.test.ts
@@ -8,6 +8,7 @@ describe("outline utility function", () => {
     [{ outlineStyle: "dotted" }, "outline-style: dotted;", ""],
     [{ outlineWidth: 1 }, "outline-width: 1px;", ""],
     [{ outlineWidth: "thin" }, "outline-width: thin;", ""],
+    [{ outlineWidth: 0 }, "outline-width: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/outline.ts
+++ b/packages/system/src/outline.ts
@@ -23,7 +23,7 @@ export const outline = (props: OutlineProps): ResponsiveStyle => {
 
   for (const key in outlineMappings) {
     const cssValue = props[key as OutlineKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = outlineMappings[key as OutlineKeys];
       const converter = [
         outlineMappings.outlineWidth,

--- a/packages/system/src/position.ts
+++ b/packages/system/src/position.ts
@@ -21,7 +21,7 @@ export const position = (props: PositionProps): ResponsiveStyle => {
 
   for (const key in positionMappings) {
     const cssValue = props[key as PositionKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = positionMappings[key as PositionKeys];
       const responsiveStyles = applyResponsiveStyles(
         property,

--- a/packages/system/src/shadow.ts
+++ b/packages/system/src/shadow.ts
@@ -15,7 +15,7 @@ export const shadow = (props: ShadowProps): ResponsiveStyle => {
 
   for (const key in shadowMappings) {
     const cssValue = props[key as ShadowKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = shadowMappings[key as ShadowKeys];
       const responsiveStyles = applyResponsiveStyles(property, cssValue);
       base += responsiveStyles.base;

--- a/packages/system/src/space.test.ts
+++ b/packages/system/src/space.test.ts
@@ -12,6 +12,7 @@ describe("space utility function", () => {
       "margin-left: 4px; margin-right: 4px;",
       "@media (min-width: 576px) { margin-left: 8px; margin-right: 8px; }",
     ],
+    [{ m: 0 }, "margin: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/space.ts
+++ b/packages/system/src/space.ts
@@ -89,7 +89,7 @@ export const space = (props: SpaceProps): ResponsiveStyle => {
 
   for (const key in spaceMappings) {
     const cssValue = props[key as SpaceKeys];
-    if (cssValue || cssValue === 0) {
+    if (cssValue != undefined) {
       const properties = spaceMappings[key as SpaceKeys].split(",");
       for (const property of properties) {
         const responsiveStyles = applyResponsiveStyles(

--- a/packages/system/src/space.ts
+++ b/packages/system/src/space.ts
@@ -89,7 +89,7 @@ export const space = (props: SpaceProps): ResponsiveStyle => {
 
   for (const key in spaceMappings) {
     const cssValue = props[key as SpaceKeys];
-    if (cssValue) {
+    if (cssValue || cssValue === 0) {
       const properties = spaceMappings[key as SpaceKeys].split(",");
       for (const property of properties) {
         const responsiveStyles = applyResponsiveStyles(

--- a/packages/system/src/text.test.ts
+++ b/packages/system/src/text.test.ts
@@ -12,6 +12,7 @@ describe("text utility function", () => {
       "text-indent: 50px;",
       "@media (min-width: 576px) { text-indent: 100px; }",
     ],
+    [{ textIndent: 0 }, "text-indent: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/text.ts
+++ b/packages/system/src/text.ts
@@ -60,7 +60,7 @@ export const text = (props: TextProps): ResponsiveStyle => {
 
   for (const key in textMappings) {
     const cssValue = props[key as TextKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = textMappings[key as TextKeys];
       const converter = [textMappings.textIndent].includes(property)
         ? toCssUnit

--- a/packages/system/src/typography.test.ts
+++ b/packages/system/src/typography.test.ts
@@ -25,6 +25,7 @@ describe("typography utility function", () => {
     [{ wordSpacing: 1 }, "word-spacing: 1px;", ""],
     [{ wordBreak: "break-all" }, "word-break: break-all;", ""],
     [{ writingMode: "vertical-rl" }, "writing-mode: vertical-rl;", ""],
+    [{ letterSpacing: 0 }, "letter-spacing: 0px;", ""],
   ];
 
   test.each(testCases)(

--- a/packages/system/src/typography.ts
+++ b/packages/system/src/typography.ts
@@ -44,7 +44,7 @@ export const typography = (props: TypographyProps): ResponsiveStyle => {
 
   for (const key in typographyMappings) {
     const cssValue = props[key as TypographyKeys];
-    if (cssValue) {
+    if (cssValue != undefined) {
       const property = typographyMappings[key as TypographyKeys];
       const converter = [
         typographyMappings.letterSpacing,


### PR DESCRIPTION
(This original post has been edited to reflect correctly the current content of PR.)
kuma-ui has some utility props but if the value of the properties are zero, the properties will be removed in spite of it is necessary.
Currently this behavior can be dismissed by the workaround of using a string `"0"` instead of numerical `0`.
This PR makes the compiler recognize falsy values except `null` and `undefined`, as valid value and fixes the behavior.

<details>
<summary>Original Post</summary>
kuma-ui has some utility props that can change components' spaces, such as m and p but if the value of the properties are zero, the properties will be removed in spite of it is necessary.
Currently this behavior can be dismissed by the workaround of using a string "0" instead of numerical 0.
This PR makes the compiler recognize numerical 0 as valid value and fixes the behavior.
</details>