### PR TITLE
Eslint followups

### DIFF
--- a/packages/babel-plugin/src/components/processComponents.ts
+++ b/packages/babel-plugin/src/components/processComponents.ts
@@ -19,7 +19,9 @@ export const processComponents = (
       const openingElement = path.node.openingElement;
       if (t.isJSXIdentifier(openingElement.name)) {
         const name = openingElement.name.name;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
         const componentType =
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- FIXME
           componentList[
             importedStyleFunctions[name] as keyof typeof componentList
           ];

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -35,9 +35,11 @@ const compile = (
       const originalComponentName = Object.keys(bindings).find(
         (key) =>
           bindings[key] === jsxTagName &&
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
           Object.values(componentList).some((c) => c === key)
       );
       if (!originalComponentName) return;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
       const componentName =
         originalComponentName as (typeof componentList)[keyof typeof componentList];
       const extractedPropsMap = collectPropsFromJsx(openingElement);

--- a/packages/compiler/src/extractor/extract.ts
+++ b/packages/compiler/src/extractor/extract.ts
@@ -82,8 +82,7 @@ export const extractProps = (
   // However, we do not want to apply the Box theme in those cases.
   if (componentName === "Box" && isDefault) {
     for (const prop in componentVariantProps) {
-      // eslint-disable-next-line no-prototype-builtins -- FIXME
-      if (componentVariantProps.hasOwnProperty(prop)) {
+      if (Object.hasOwn(componentVariantProps, prop)) {
         delete componentVariantProps[prop];
       }
     }

--- a/packages/compiler/src/extractor/extract.ts
+++ b/packages/compiler/src/extractor/extract.ts
@@ -37,11 +37,14 @@ export const extractProps = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FIXME
   const componentVariantProps: { [key: string]: any } = {};
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- FIXME
   const defaultProps = componentDefaultProps(componentName);
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
   const variant = theme.getVariants(componentName);
   let isDefault = false;
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
   for (const [propName, propValue] of Object.entries({
     ...defaultProps,
     ...propsMap,
@@ -50,6 +53,7 @@ export const extractProps = (
       styledProps[propName.trim()] = propValue;
     } else if (isPseudoProps(propName.trim())) {
       pseudoProps[propName.trim()] = propValue;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- FIXME
     } else if (isComponentProps(componentName)(propName.trim())) {
       componentProps[propName.trim()] = propValue;
     } else if (propName.trim() === "variant") {
@@ -76,6 +80,7 @@ export const extractProps = (
     return;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call -- FIXME
   const specificProps = componentHandler(componentName)(componentProps);
 
   // Every component internally uses the Box component.
@@ -88,16 +93,19 @@ export const extractProps = (
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
   const combinedProps = {
     ...componentVariantProps,
     ...specificProps,
     ...styledProps,
     ...pseudoProps,
   };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
   const key = generateKey(combinedProps);
   let generatedStyle = styleCache[key];
   // If the result isn't in the cache, generate it and save it to the cache
   if (!generatedStyle) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- FIXME
     generatedStyle = new StyleGenerator(combinedProps).getStyle();
     styleCache[key] = generatedStyle;
   }

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -26,15 +26,13 @@ export function flattenObject<const T, T2 extends NestedObject<T>>(
 ): FlattenObject<T2> {
   const result = {} as FlattenObject<T2>;
   for (const key in object) {
-    // eslint-disable-next-line no-prototype-builtins -- FIXME
-    if (!object.hasOwnProperty(key)) continue;
+    if (!Object.hasOwn(object, key)) continue;
     const value = object[key];
 
     if (typeof value == "object" && value !== null) {
       const _object = flattenObject(value as NestedObject);
       for (const _key in _object) {
-        // eslint-disable-next-line no-prototype-builtins -- FIXME
-        if (!_object.hasOwnProperty(_key)) continue;
+        if (!Object.hasOwn(_object, _key)) continue;
         //@ts-expect-error type
         result[key + "." + _key] = _object[_key];
       }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -67,9 +67,7 @@ export default function kumaUI(): Plugin {
         .relative(process.cwd(), cssFilename)
         .replace(/\\/g, path.posix.sep);
       // const css = sheet.getCSS();
-      const css =
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- FIXME
-        ((result.metadata as unknown as { css: string }).css as string) || "";
+      const css = (result.metadata as unknown as { css: string }).css || "";
       cssLookup[cssRelativePath] = css;
       sheet.reset();
       return (

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -32,15 +32,13 @@ const kumaUiLoader: RawLoaderDefinitionFunction<Options> = function (
 
   const outputPath = this._compiler?.options.output.path;
   if (!outputPath) throw Error("output path is not correctly set");
-  const result = transform(source.toString(), id)
+  const result = transform(source.toString(), id);
   if (!result || !result.code) {
     callback(null, source);
     return;
   }
 
-  const css =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- FIXME
-    ((result.metadata as unknown as { css: string }).css as string) || "";
+  const css = (result.metadata as unknown as { css: string }).css || "";
 
   if (css) {
     const codePrefix = fileLoader(css, {


### PR DESCRIPTION
This PR is small follow ups after https://github.com/poteboy/kuma-ui/pull/238. Each commit message should describe what it does.

I just realized our GitHub actions do not run `pnpm run lint` so new PRs with failing lint are being merged 😅  If the maintainers are fine, I can try adding lint to the Github Actions in this PR as well 

## The usage of Object.hasOwn
According to [Node.js releases](https://nodejs.dev/en/about/releases/), Node.js v16 is the "Maintenance LTS" and the current active LTS is v18.
Also there should be no reason not to update Node.js minor versions.
So I think it's reasonable to assume that people are using Node.js newer than 16.9.0, which means we can use new APIs such as [Object.hasOwn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) for plugins (runtime is different, which runs in browsers!) I think it's better to clarify supported Node.js versions in docs and engines field in package.json but it's out of scope for this PR

Or actually we can just drop hasOwn checks if we believe in modern environment, no one pollutes Object.prototype :)



